### PR TITLE
fix: support alternative claude-code package paths and prevent stdout pollution

### DIFF
--- a/server.js
+++ b/server.js
@@ -598,7 +598,7 @@ export async function startViewer() {
   return new Promise((resolve, reject) => {
     function tryListen(port) {
       if (port > MAX_PORT) {
-        console.log(t('server.portsBusy', { start: START_PORT, end: MAX_PORT }));
+        console.error(t('server.portsBusy', { start: START_PORT, end: MAX_PORT }));
         resolve(null);
         return;
       }
@@ -609,7 +609,7 @@ export async function startViewer() {
         server = currentServer;
         actualPort = port;
         const url = `http://${HOST}:${port}`;
-        console.log(t('server.started', { host: HOST, port }));
+        console.error(t('server.started', { host: HOST, port }));
         // v2.0.69 之前的版本会清空控制台，自动打开浏览器确保用户能看到界面
         try {
           const ccPkgPath = join(__dirname, '..', '@anthropic-ai', 'claude-code', 'package.json');


### PR DESCRIPTION
## Problem

1. **cli.js hardcodes `@anthropic-ai/claude-code/cli.js` path** using `__dirname` relative resolution. This fails when cc-viewer is installed via `npm install -g .` (symlink install) because `__dirname` points to the source directory instead of global `node_modules`. It also doesn't support alternative packages like `@ali/claude-code`.

2. **server.js uses `console.log` for startup messages**, which pollutes stdout and breaks editors (e.g. Zed) that communicate with Claude Code via stdio JSON-RPC protocol, causing `Query closed before response received` errors.

## Fix

- **cli.js**: Replace hardcoded path with `resolveClaudeCodeCliPath()` that searches both `__dirname` parent and `npm root -g` global directory, supporting `@anthropic-ai/claude-code` and `@ali/claude-code` packages.
- **cli.js**: Update `buildShellHook()` to detect both package candidates.
- **server.js**: Change `console.log` → `console.error` for server startup messages to avoid stdout pollution.

## Testing

- Verified cc-viewer works correctly with `@ali/claude-code` after the fix
- Verified Zed editor no longer shows `Query closed before response received` error