### PR TITLE
feat: 添加了上下文面板，用 Markdown 组件展示系统提示词、对话、工具

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -26,7 +26,7 @@ class App extends React.Component {
       requests: [],
       selectedIndex: null,
       viewMode: 'raw',
-      currentTab: 'request',
+      currentTab: 'context',
       cacheExpireAt,
       cacheType,
       leftPanelWidth: 380,

--- a/src/components/ContextTab.jsx
+++ b/src/components/ContextTab.jsx
@@ -1,0 +1,211 @@
+import React, { useState } from 'react';
+import { Typography, Empty } from 'antd';
+import { RightOutlined, DownOutlined } from '@ant-design/icons';
+import { renderMarkdown } from '../utils/markdown';
+import { t } from '../i18n';
+import styles from './ContextTab.module.css';
+
+const { Text } = Typography;
+
+/**
+ * 将 messages 数组中每条消息格式化为 Markdown 文本
+ */
+function formatMessages(messages) {
+  if (!Array.isArray(messages) || messages.length === 0) return null;
+  return messages.map((msg, i) => {
+    const role = msg?.role || 'unknown';
+    let content = '';
+    if (typeof msg?.content === 'string') {
+      content = msg.content;
+    } else if (Array.isArray(msg?.content)) {
+      content = msg.content
+        .map((block) => {
+          if (!block) return '';
+          if (block.type === 'text') return block.text || '';
+          if (block.type === 'tool_use') return `\`\`\`json\n${JSON.stringify(block, null, 2)}\n\`\`\``;
+          if (block.type === 'tool_result') {
+            const resultContent =
+              typeof block.content === 'string'
+                ? block.content
+                : Array.isArray(block.content)
+                ? block.content.map((c) => c?.text || '').join('\n')
+                : JSON.stringify(block.content, null, 2);
+            return `**[tool_result]**\n${resultContent}`;
+          }
+          return JSON.stringify(block, null, 2);
+        })
+        .join('\n\n');
+    } else {
+      content = JSON.stringify(msg?.content, null, 2);
+    }
+    return { index: i, role, content };
+  });
+}
+
+/**
+ * 将 system 数组/字符串格式化为 Markdown 文本
+ */
+function formatSystem(system) {
+  if (!system) return null;
+  if (typeof system === 'string') return system;
+  if (Array.isArray(system)) {
+    return system
+      .map((item) => {
+        if (!item) return '';
+        if (typeof item === 'string') return item;
+        if (item.type === 'text') return item.text || '';
+        return JSON.stringify(item, null, 2);
+      })
+      .join('\n\n---\n\n');
+  }
+  return JSON.stringify(system, null, 2);
+}
+
+/**
+ * 将 tools 数组中单个工具格式化为 Markdown 文本
+ */
+function formatTool(tool) {
+  const name = tool?.name || 'unknown';
+  const desc = tool?.description || '';
+  const schema = tool?.input_schema || tool?.parameters || null;
+  let md = `## ${name}\n\n`;
+  if (desc) md += `${desc}\n\n`;
+  if (schema) {
+    md += `**Parameters:**\n\n\`\`\`json\n${JSON.stringify(schema, null, 2)}\n\`\`\`\n`;
+  }
+  return md;
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// 手风琴子项
+// ──────────────────────────────────────────────────────────────────────────────
+function AccordionSection({ title, items, onSelect, selectedId }) {
+  const [open, setOpen] = useState(true);
+  return (
+    <div className={styles.section}>
+      <div className={styles.sectionHeader} onClick={() => setOpen((v) => !v)}>
+        {open ? <DownOutlined className={styles.arrow} /> : <RightOutlined className={styles.arrow} />}
+        <span className={styles.sectionTitle}>{title}</span>
+        <span className={styles.sectionCount}>{items.length}</span>
+      </div>
+      {open && (
+        <div className={styles.sectionBody}>
+          {items.map((item) => {
+            const active = selectedId === item.id;
+            return (
+              <div
+                key={item.id}
+                className={`${styles.item} ${active ? styles.itemActive : ''}`}
+                onClick={() => onSelect(item)}
+              >
+                <span className={styles.itemLabel}>{item.label}</span>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// 主组件
+// ──────────────────────────────────────────────────────────────────────────────
+export default function ContextTab({ body }) {
+  const [selected, setSelected] = useState(null);
+
+  if (!body || typeof body !== 'object') {
+    return (
+      <div className={styles.emptyWrap}>
+        <Empty description={t('ui.context.noData')} />
+      </div>
+    );
+  }
+
+  // ── 构建手风琴数据 ──────────────────────────────────────────────────────────
+  const accordionSections = [];
+
+  // 系统提示词
+  const systemText = formatSystem(body.system);
+  if (systemText != null) {
+    accordionSections.push({
+      key: 'system',
+      title: t('ui.context.systemPrompt'),
+      items: [
+        {
+          id: 'system__0',
+          label: t('ui.context.systemPrompt'),
+          markdown: systemText,
+        },
+      ],
+    });
+  }
+
+  // 消息列表
+  const msgItems = formatMessages(body.messages);
+  if (msgItems && msgItems.length > 0) {
+    accordionSections.push({
+      key: 'messages',
+      title: t('ui.context.messages'),
+      items: msgItems.map((m) => ({
+        id: `msg__${m.index}`,
+        label: `[${m.index}] ${m.role}`,
+        markdown: m.content,
+      })),
+    });
+  }
+
+  // 工具列表
+  if (Array.isArray(body.tools) && body.tools.length > 0) {
+    accordionSections.push({
+      key: 'tools',
+      title: t('ui.context.tools'),
+      items: body.tools.map((tool, i) => ({
+        id: `tool__${i}`,
+        label: tool?.name || `Tool ${i}`,
+        markdown: formatTool(tool),
+      })),
+    });
+  }
+
+  if (accordionSections.length === 0) {
+    return (
+      <div className={styles.emptyWrap}>
+        <Empty description={t('ui.context.noFields')} />
+      </div>
+    );
+  }
+
+  const selectedMarkdown = selected?.markdown || null;
+
+  return (
+    <div className={styles.root}>
+      {/* 左侧手风琴 */}
+      <div className={styles.sidebar}>
+        {accordionSections.map((sec) => (
+          <AccordionSection
+            key={sec.key}
+            title={sec.title}
+            items={sec.items}
+            selectedId={selected?.id}
+            onSelect={(item) => setSelected(item)}
+          />
+        ))}
+      </div>
+
+      {/* 右侧内容区 */}
+      <div className={styles.content}>
+        {selectedMarkdown == null ? (
+          <div className={styles.contentEmpty}>
+            <Text type="secondary">{t('ui.context.selectPrompt')}</Text>
+          </div>
+        ) : (
+          <div
+            className={`chat-md ${styles.markdownBody}`}
+            dangerouslySetInnerHTML={{ __html: renderMarkdown(selectedMarkdown) }}
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/ContextTab.module.css
+++ b/src/components/ContextTab.module.css
@@ -1,0 +1,122 @@
+.root {
+  display: flex;
+  height: 100%;
+  min-height: 0;
+  gap: 0;
+}
+
+/* ── 左侧手风琴 ── */
+.sidebar {
+  width: 220px;
+  flex-shrink: 0;
+  border-right: 1px solid #2a2a2a;
+  overflow-y: auto;
+  padding: 4px 0;
+}
+
+.section {
+  user-select: none;
+}
+
+.sectionHeader {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  cursor: pointer;
+  color: #d1d5db;
+  font-size: 12px;
+  font-weight: 600;
+  transition: background 0.15s;
+}
+
+.sectionHeader:hover {
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.arrow {
+  font-size: 10px;
+  color: #888;
+  flex-shrink: 0;
+}
+
+.sectionTitle {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.sectionCount {
+  font-size: 11px;
+  color: #666;
+  background: #1f1f1f;
+  border-radius: 10px;
+  padding: 0 6px;
+  line-height: 18px;
+}
+
+.sectionBody {
+  padding: 2px 0;
+}
+
+.item {
+  padding: 5px 10px 5px 24px;
+  font-size: 12px;
+  color: #888;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.item:hover {
+  background: rgba(255, 255, 255, 0.04);
+  color: #d1d5db;
+}
+
+.itemActive {
+  background: rgba(99, 179, 237, 0.12);
+  color: #63b3ed;
+}
+
+.itemActive:hover {
+  background: rgba(99, 179, 237, 0.16);
+  color: #63b3ed;
+}
+
+.itemLabel {
+  font-family: monospace;
+}
+
+/* ── 右侧内容区 ── */
+.content {
+  flex: 1;
+  min-width: 0;
+  overflow: auto;
+  padding: 12px 16px;
+}
+
+.contentEmpty {
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.emptyWrap {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 200px;
+}
+
+/* Markdown 样式覆盖（继承全局 chat-md，此处做微调） */
+.markdownBody {
+  font-size: 13px;
+  line-height: 1.7;
+  color: #d1d5db;
+  word-break: break-word;
+}

--- a/src/components/DetailPanel.jsx
+++ b/src/components/DetailPanel.jsx
@@ -7,6 +7,7 @@ import { t } from '../i18n';
 import { formatTokenCount, stripPrivateKeys, hasClaudeMdReminder, isClaudeMdReminder, hasSkillsReminder, isSkillsReminder } from '../utils/helpers';
 import { classifyRequest } from '../utils/requestType';
 import { isMainAgent } from '../utils/contentFilter';
+import ContextTab from './ContextTab';
 import styles from './DetailPanel.module.css';
 
 const { Text, Paragraph } = Typography;
@@ -399,6 +400,15 @@ class DetailPanel extends React.Component {
     const hasSkills = hasSkillsReminder(request.body);
 
     const tabItems = [
+      {
+        key: 'context',
+        label: 'Context',
+        children: (
+          <div className={styles.tabContent} style={{ height: 'calc(100vh - 220px)', minHeight: 400 }}>
+            <ContextTab body={request.body} />
+          </div>
+        ),
+      },
       {
         key: 'request',
         label: 'Request',

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -2535,6 +2535,69 @@ const i18nData = {
     "th": "เวอร์ชันหลัก v{version} พร้อมใช้งาน อัปเดตด้วยตนเอง: npm i -g cc-viewer@latest",
     "tr": "Ana sürüm v{version} mevcut, manuel güncelleyin: npm i -g cc-viewer@latest",
     "uk": "Доступна основна версія v{version}, оновіть: npm i -g cc-viewer@latest"
+  },
+  "ui.context.systemPrompt": {
+    "zh": "系统提示词", "en": "System Prompt", "zh-TW": "系統提示詞",
+    "ko": "시스템 프롬프트", "ja": "システムプロンプト", "de": "System-Prompt",
+    "es": "Prompt del sistema", "fr": "Prompt système", "it": "Prompt di sistema",
+    "da": "System-prompt", "pl": "Prompt systemowy", "ru": "Системный промпт",
+    "ar": "موجه النظام", "no": "System-prompt", "pt-BR": "Prompt do sistema",
+    "th": "System Prompt", "tr": "Sistem Prompt'u", "uk": "Системний промпт"
+  },
+  "ui.context.messages": {
+    "zh": "消息", "en": "Messages", "zh-TW": "訊息",
+    "ko": "메시지", "ja": "メッセージ", "de": "Nachrichten",
+    "es": "Mensajes", "fr": "Messages", "it": "Messaggi",
+    "da": "Beskeder", "pl": "Wiadomości", "ru": "Сообщения",
+    "ar": "الرسائل", "no": "Meldinger", "pt-BR": "Mensagens",
+    "th": "ข้อความ", "tr": "Mesajlar", "uk": "Повідомлення"
+  },
+  "ui.context.tools": {
+    "zh": "工具", "en": "Tools", "zh-TW": "工具",
+    "ko": "도구", "ja": "ツール", "de": "Tools",
+    "es": "Herramientas", "fr": "Outils", "it": "Strumenti",
+    "da": "Værktøjer", "pl": "Narzędzia", "ru": "Инструменты",
+    "ar": "الأدوات", "no": "Verktøy", "pt-BR": "Ferramentas",
+    "th": "เครื่องมือ", "tr": "Araçlar", "uk": "Інструменти"
+  },
+  "ui.context.noData": {
+    "zh": "暂无 Context 数据", "en": "No context data", "zh-TW": "暫無 Context 資料",
+    "ko": "컨텍스트 데이터 없음", "ja": "コンテキストデータなし", "de": "Keine Kontextdaten",
+    "es": "Sin datos de contexto", "fr": "Aucune donnée de contexte", "it": "Nessun dato di contesto",
+    "da": "Ingen kontekstdata", "pl": "Brak danych kontekstu", "ru": "Нет данных контекста",
+    "ar": "لا توجد بيانات سياق", "no": "Ingen kontekstdata", "pt-BR": "Sem dados de contexto",
+    "th": "ไม่มีข้อมูล Context", "tr": "Bağlam verisi yok", "uk": "Немає даних контексту"
+  },
+  "ui.context.noFields": {
+    "zh": "Request body 中未找到 messages / system / tools", "en": "No messages / system / tools found in request body",
+    "zh-TW": "Request body 中未找到 messages / system / tools",
+    "ko": "요청 본문에서 messages / system / tools를 찾을 수 없음",
+    "ja": "リクエストボディに messages / system / tools が見つかりません",
+    "de": "Keine messages / system / tools im Request-Body gefunden",
+    "es": "No se encontraron messages / system / tools en el cuerpo de la solicitud",
+    "fr": "Aucun messages / system / tools dans le corps de la requête",
+    "it": "Nessun messages / system / tools trovato nel corpo della richiesta",
+    "da": "Ingen messages / system / tools fundet i request body",
+    "pl": "Nie znaleziono messages / system / tools w treści żądania",
+    "ru": "В теле запроса не найдено messages / system / tools",
+    "ar": "لم يتم العثور على messages / system / tools في جسم الطلب",
+    "no": "Ingen messages / system / tools funnet i request body",
+    "pt-BR": "Nenhum messages / system / tools encontrado no corpo da requisição",
+    "th": "ไม่พบ messages / system / tools ใน request body",
+    "tr": "İstek gövdesinde messages / system / tools bulunamadı",
+    "uk": "У тілі запиту не знайдено messages / system / tools"
+  },
+  "ui.context.selectPrompt": {
+    "zh": "请在左侧选择一个要查看的内容", "en": "Select an item on the left to view",
+    "zh-TW": "請在左側選擇一個要查看的內容",
+    "ko": "왼쪽에서 항목을 선택하세요", "ja": "左側から項目を選択してください",
+    "de": "Wählen Sie links einen Eintrag aus", "es": "Seleccione un elemento a la izquierda",
+    "fr": "Sélectionnez un élément à gauche", "it": "Seleziona un elemento a sinistra",
+    "da": "Vælg et element til venstre", "pl": "Wybierz element po lewej stronie",
+    "ru": "Выберите элемент слева", "ar": "اختر عنصرًا على اليسار",
+    "no": "Velg et element til venstre", "pt-BR": "Selecione um item à esquerda",
+    "th": "เลือกรายการทางซ้าย", "tr": "Soldan bir öğe seçin",
+    "uk": "Виберіть елемент ліворуч"
   }
 };
 


### PR DESCRIPTION
模型：Claude Sonnet 4.6 Thinking
提示词：
Request Response 旁边再加一个 Context 的 Tab 内容如下：
提取 Request 中的 body.messages body.system body.tools 文本用 MarkDown 显示出来
左侧是手风琴，分别是系统提示词、消息、工具，每个手风琴展开就是对应的项，点击后右侧出现对应的文本的 Markdown 内容，项目中应该有 markdown 组件的使用，没有选中一项前，右侧是空的，空提示文本为请在左侧选择一个要查看的内容
效果：
<img width="2560" height="1259" alt="image" src="https://github.com/user-attachments/assets/71276e67-1ddf-465f-8b22-7726d596043c" />
