### PR TITLE
feat: add --file view-only mode for opening specific log files

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -634,11 +634,13 @@ async function runViewMode(filePath) {
   // No proxy, no PTY, no Claude instance
   const serverMod = await import('./server.js');
 
-  // Poll until server is ready
-  await new Promise(resolve => {
+  // Poll until server is ready (timeout after 15s)
+  const startTime = Date.now();
+  await new Promise((resolve, reject) => {
     const check = () => {
       const port = serverMod.getPort();
       if (port) resolve(port);
+      else if (Date.now() - startTime > 15000) reject(new Error('Timed out waiting for server to start'));
       else setTimeout(check, 100);
     };
     setTimeout(check, 200);
@@ -665,14 +667,13 @@ async function runViewMode(filePath) {
   process.on('SIGTERM', cleanup);
 }
 
-const fileIdx = args.indexOf('--file');
-if (fileIdx !== -1 && args[fileIdx + 1]) {
-  runViewMode(args[fileIdx + 1]).catch(err => {
+if (args[0] === 'run') {
+  runProxyCommand(args);
+} else if (args.indexOf('--file') !== -1 && args[args.indexOf('--file') + 1]) {
+  runViewMode(args[args.indexOf('--file') + 1]).catch(err => {
     console.error('View mode error:', err);
     process.exit(1);
   });
-} else if (args[0] === 'run') {
-  runProxyCommand(args);
 } else {
   // 默认行为：所有参数透传给 claude（通过 PTY + Web Viewer）
   // 展开快捷方式：--d → --dangerously-skip-permissions, --ad → --allow-dangerously-skip-permissions

--- a/cli.js
+++ b/cli.js
@@ -615,7 +615,63 @@ if (isLogger) {
   process.exit(0);
 }
 
-if (args[0] === 'run') {
+// View-only mode: open a specific log file without starting Claude
+async function runViewMode(filePath) {
+  const absPath = resolve(filePath);
+  if (!existsSync(absPath)) {
+    console.error(`Log file not found: ${absPath}`);
+    process.exit(1);
+  }
+  if (!absPath.endsWith('.jsonl')) {
+    console.error('Invalid file type. Only .jsonl files are supported.');
+    process.exit(1);
+  }
+
+  // Tell interceptor to use this file directly (no new file creation, no resume)
+  process.env.CCV_VIEW_FILE = absPath;
+
+  // Import server.js — auto-starts viewer via _initPromise.then(startViewer)
+  // No proxy, no PTY, no Claude instance
+  const serverMod = await import('./server.js');
+
+  // Poll until server is ready
+  await new Promise(resolve => {
+    const check = () => {
+      const port = serverMod.getPort();
+      if (port) resolve(port);
+      else setTimeout(check, 100);
+    };
+    setTimeout(check, 200);
+  });
+
+  const port = serverMod.getPort();
+  const protocol = serverMod.getProtocol();
+  const accessUrl = serverMod.getAccessUrl();
+
+  // Open browser (only useful on local machine)
+  try {
+    const cmd = process.platform === 'darwin' ? 'open' : process.platform === 'win32' ? 'start' : 'xdg-open';
+    const { execSync } = await import('node:child_process');
+    execSync(`${cmd} ${accessUrl}`, { stdio: 'ignore', timeout: 5000 });
+  } catch {}
+
+  console.log(accessUrl);
+
+  // Block until exit
+  const cleanup = () => {
+    serverMod.stopViewer().finally(() => process.exit());
+  };
+  process.on('SIGINT', cleanup);
+  process.on('SIGTERM', cleanup);
+}
+
+const fileIdx = args.indexOf('--file');
+if (fileIdx !== -1 && args[fileIdx + 1]) {
+  runViewMode(args[fileIdx + 1]).catch(err => {
+    console.error('View mode error:', err);
+    process.exit(1);
+  });
+} else if (args[0] === 'run') {
   runProxyCommand(args);
 } else {
   // 默认行为：所有参数透传给 claude（通过 PTY + Web Viewer）

--- a/interceptor.js
+++ b/interceptor.js
@@ -147,8 +147,15 @@ let _teamName = null;
 
 // 初始化日志文件路径（异步，支持用户交互）
 // 工作区模式下延迟到选择工作区后再初始化
+// View-only 模式下直接使用指定文件，不创建新日志
 let _newLogFile, _logDir, _projectName;
-if (process.env.CCV_WORKSPACE_MODE === '1') {
+const _viewFile = process.env.CCV_VIEW_FILE;
+if (_viewFile) {
+  // View-only: point at an existing log file, no new file creation
+  _projectName = basename(dirname(_viewFile));
+  _logDir = dirname(_viewFile);
+  _newLogFile = _viewFile;
+} else if (process.env.CCV_WORKSPACE_MODE === '1') {
   _newLogFile = '';
   _logDir = '';
   _projectName = '';
@@ -168,6 +175,7 @@ if (process.env.CCV_WORKSPACE_MODE === '1') {
 let LOG_FILE = _newLogFile;
 
 const _initPromise = (async () => {
+  if (_viewFile) return; // View-only: no resume logic, LOG_FILE already set
   if (!_logDir || !_projectName) return; // 工作区模式下跳过
   if (_isTeammate) return; // Teammate 已在上方同步初始化，跳过 async resume 流程
   try {

--- a/server.js
+++ b/server.js
@@ -2553,6 +2553,11 @@ export function getAccessToken() {
   return ACCESS_TOKEN;
 }
 
+export function getAccessUrl() {
+  const ip = getLocalIp();
+  return `${serverProtocol}://${ip}:${actualPort}?token=${ACCESS_TOKEN}`;
+}
+
 // 流式状态 SSE 推送定时器：检测 streamingState 变化并广播给所有客户端
 let _streamingStatusTimer = null;
 let _lastStreamingActive = false;


### PR DESCRIPTION
## Summary

- Add `ccv --file path/to/session.jsonl` to open a specific log file in the web viewer **without starting Claude or the API proxy**
- Supports live refresh for active sessions — the file watcher polls at 500ms intervals, so if a proxy is still writing to the file, new entries appear in real-time
- Export `getAccessUrl()` from server.js for LAN URL with token

## Use Case

Integration with [lia](https://github.com/crhan/lia) (multi-agent collaboration platform): `lia session view lia:220` opens the cc-viewer for that session's log file. Previously required `--workspace` which shows all logs in a directory; now `--file` targets exactly one log.

## Changes

| File | Change |
|------|--------|
| `interceptor.js` | `CCV_VIEW_FILE` env var fast-path: sets `LOG_FILE`/`_projectName`/`_logDir` directly, skips new file creation and resume logic |
| `server.js` | Export `getAccessUrl()` — returns `protocol://ip:port?token=xxx` for remote access |
| `cli.js` | `runViewMode()` — validates file, sets env, imports server (auto-starts viewer), outputs access URL |

## Test plan

- [x] `ccv --file ~/.claude/cc-viewer/project/project_YYYYMMDD_HHMMSS.jsonl` starts server, opens browser, displays log
- [x] No Claude instance spawned
- [x] `/api/local-log?file=...` SSE endpoint returns correct entries
- [x] `/api/local-logs` lists all projects, `_currentProject` matches the file's project
- [x] LAN URL with token printed to stdout for remote access
- [ ] Live refresh: open viewer on an active session's log, verify new entries appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)