### PR TITLE
fix: 自动审批默认倒计时从 10 秒缩短为 3 秒

### DIFF
--- a/history.md
+++ b/history.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.6.134 (2026-04-09)
+
+- Change: auto-approve default countdown 10s → 3s (enabling auto-approve should feel fast; dropdown still offers 5/10/15/20/30/60s)
+
 ## 1.6.131 (2026-04-09)
 
 - Feat: terminal panel focus border animation (4px + box-shadow glow, 0.3s ease-out)

--- a/src/components/ToolApprovalPanel.jsx
+++ b/src/components/ToolApprovalPanel.jsx
@@ -2,7 +2,7 @@ import React, { useMemo, useRef, useEffect, useCallback, useState } from 'react'
 import { t } from '../i18n';
 import styles from './ToolApprovalPanel.module.css';
 
-const DEFAULT_AUTO_SECONDS = 10;
+const DEFAULT_AUTO_SECONDS = 3;
 
 function ToolApprovalPanel({ toolName, toolInput, requestId, onAllow, onAllowSession, onDeny, visible, global: isGlobal, autoApproveSeconds = 0, onAutoApproveChange }) {
   const panelRef = useRef(null);


### PR DESCRIPTION
## 背景

开启「自动审批」后,每次工具调用面板都会弹出一个 **10 秒** 倒计时,然后才自动通过。这个体验有点奇怪 —— 既然用户主动选择了「自动审批」,就已经表达了「我信任,别挡路」的意图,再让他等 10 秒本质上是在和用户的选择对着干。

## 为什么要改

1. **10 秒违背了自动审批的设计意图**
   倒计时的目的是给一个「最后反悔」的窗口,让用户在自动通过前有机会按 Deny/Esc 中断。但 10 秒既不是「快速放行」也不是「充分审核」,夹在中间两头不讨好:
   - 想快的人觉得拖沓
   - 想仔细看的人本来就不会开自动审批

2. **每次工具调用都要等 10 秒,累积体感很差**
   一次对话里 Claude 可能触发十几次工具调用,每次都卡 10 秒 = 白白等将近 2 分钟,严重打断心流。

3. **3 秒是合理折中**
   - 足够看清工具名称和关键参数,风险操作仍有反悔机会
   - 又不会让信任这个功能的用户感到被拖累
   - 对比极端方案:
     - **0 秒** 立即通过 → 彻底失去拦截能力,`rm -rf` 类操作没机会叫停
     - **保持 10 秒** → 继续拖沓

## 改动

仅一行:`src/components/ToolApprovalPanel.jsx:5`

```diff
-const DEFAULT_AUTO_SECONDS = 10;
+const DEFAULT_AUTO_SECONDS = 3;
```

这个常量只影响「点击开启自动审批按钮」时的默认值。设置面板下拉菜单里的 `5s / 10s / 15s / 20s / 30s / 60s` 选项完全保留,需要更长缓冲窗口的用户仍可自由选择。已开启并保存为其他秒数的用户不受影响(持久化读取的是 `autoApproveSeconds` 数值,与常量解耦)。

## 测试计划

- [x] `npm run test` — 830 个单测全部通过
- [x] `npm run build` — 构建无报错
- [x] 手动验证:打开一次工具审批面板,点击「开启自动审批」,确认倒计时从 3 秒开始
- [x] 手动验证:下拉菜单仍能切换到 5/10/15/20/30/60s,每个值都正常生效
- [x] 手动验证:历史已保存的 `autoApproveSeconds`(如用户之前选过 10s)在重启后仍然是 10s

🤖 Generated with [Claude Code](https://claude.com/claude-code)