### PR TITLE
feat: expose httpServer to serverStarted plugin hook

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -122,13 +122,13 @@ Triggered after the HTTP server starts successfully.
 | Property | Description |
 |----------|-------------|
 | **Type** | Parallel (concurrent notification) |
-| **Parameters** | `{ port, host, url, ip, token, protocol }` |
+| **Parameters** | `{ port, host, url, ip, token, protocol, httpServer }` |
 | **Returns** | Ignored |
 | **Timing** | After server binds to a port |
 
 ```javascript
 hooks: {
-  async serverStarted({ port, host, url, ip, token, protocol }) {
+  async serverStarted({ port, host, url, ip, token, protocol, httpServer }) {
     console.error(`[my-plugin] Server is running at ${url}`);
   },
 }

--- a/docs/plugins.zh.md
+++ b/docs/plugins.zh.md
@@ -70,7 +70,7 @@ export default {
 |-----------|------|------|--------|---------|
 | `httpsOptions` | waterfall | `{}` | `{ pfx, passphrase }` 或 `{ cert, key }` | 服务器创建前 |
 | `localUrl` | waterfall | `{ url, ip, port, token }` | `{ url }` | 客户端请求局域网地址时 |
-| `serverStarted` | parallel | `{ port, host, url, ip, token, protocol }` | 忽略 | 服务器启动成功后 |
+| `serverStarted` | parallel | `{ port, host, url, ip, token, protocol, httpServer }` | 忽略 | 服务器启动成功后 |
 | `serverStopping` | parallel | `{}` | 忽略 | 服务器关闭前 |
 | `onNewEntry` | parallel | `entry` (JSONL 日志条目对象) | 忽略 | 检测到新的 JSONL 日志条目时 |
 
@@ -168,7 +168,7 @@ hooks: {
 
 ```javascript
 hooks: {
-  async serverStarted({ port, host, url, ip, token, protocol }) {
+  async serverStarted({ port, host, url, ip, token, protocol, httpServer }) {
     console.error(`[my-plugin] 服务器运行在 ${url}`);
 
     // 示例：通知企业监控系统

--- a/server.js
+++ b/server.js
@@ -2708,7 +2708,7 @@ export async function startViewer() {
           currentServer = createServer(handleRequest);
         }
 
-        currentServer.listen(port, HOST, () => {
+        currentServer.listen(port, HOST, async () => {
           server = currentServer;
           actualPort = port;
           const url = `${serverProtocol}://127.0.0.1:${port}`;
@@ -2737,12 +2737,12 @@ export async function startViewer() {
             startStatsWorker();
             startStreamingStatusTimer();
           }
-          // CLI 模式下启动 WebSocket 服务
+          // CLI 模式下启动 WebSocket 服务 (必须 await，否则插件 hook 拿不到 upgrade listeners)
           if (isCliMode) {
-            setupTerminalWebSocket(currentServer);
+            await setupTerminalWebSocket(currentServer);
           }
           // 通知插件服务器已启动
-          runParallelHook('serverStarted', { port, host: HOST, url, ip: getLocalIp(), token: ACCESS_TOKEN, protocol: serverProtocol })
+          runParallelHook('serverStarted', { port, host: HOST, url, ip: getLocalIp(), token: ACCESS_TOKEN, protocol: serverProtocol, httpServer: currentServer })
             .catch(err => console.error('[CC Viewer] Plugin serverStarted hook error:', err.message));
           resolve(server);
         });


### PR DESCRIPTION
- Pass httpServer instance to the serverStarted parallel hook, enabling plugins to intercept upgrade/request events (e.g. adding custom WebSocket endpoints).
- Await setupTerminalWebSocket before running plugin hooks to prevent a race condition where the terminal upgrade handler registers after plugins save existing listeners, causing socket.destroy() on non-/ws/terminal paths.
- Update plugin docs (EN + ZH) with the new httpServer parameter.