### PR TITLE
feat: plugin system hooks (beforeRequest/onPermRequest/onAskRequest/onPlanRequest) + HTTPS bridge support

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -362,11 +362,12 @@ async function runCliMode(extraClaudeArgs = [], cwd, noOpen = false) {
   });
 
   const port = serverMod.getPort();
+  const serverProtocol = serverMod.getProtocol();
 
   // 3. 启动 PTY 中的 claude
   const { spawnClaude, killPty } = await import('./pty-manager.js');
   try {
-    await spawnClaude(proxyPort, workingDir, extraClaudeArgs, claudePath, isNpmVersion, port);
+    await spawnClaude(proxyPort, workingDir, extraClaudeArgs, claudePath, isNpmVersion, port, serverProtocol);
   } catch (err) {
     console.error('[CC Viewer] Failed to spawn Claude:', err.message);
     await serverMod.stopViewer();
@@ -456,6 +457,7 @@ async function runSdkMode(extraClaudeArgs = [], cwd, noOpen = false) {
     onStreamingStatus: (data) => serverMod.setSdkStreamingState(data),
     broadcastWs: (msg) => serverMod.broadcastWsMessage(msg),
     permissionMode,
+    runWaterfallHook: (await import('./lib/plugin-loader.js')).runWaterfallHook,
   });
 
   // 注册 SDK 回调到 server.js（WS 消息路由用）

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -61,6 +61,38 @@ export default {
 
 ## Available Hooks
 
+### `beforeRequest` — Waterfall
+
+Triggered on every HTTP request, after token authentication but before route dispatching. Allows plugins to intercept and handle custom API endpoints.
+
+| Property | Description |
+|----------|-------------|
+| **Type** | Waterfall (serial pipeline) |
+| **Parameters** | `{ req, res, url, method, parsedUrl, handled }` |
+| **Returns** | `{ handled: true }` to short-circuit the request (skip cc-viewer routing) |
+| **Timing** | After token auth, before route dispatch |
+
+- `req` / `res` — Node.js `IncomingMessage` / `ServerResponse` objects
+- `url` — the pathname (e.g., `/api/plugin/my-endpoint`)
+- `method` — HTTP method (`GET`, `POST`, etc.)
+- `parsedUrl` — the full `URL` object
+- `handled` — starts as `false`; return `{ handled: true }` if your plugin wrote the response
+
+> **Important:** Only return `{ handled: true }`. Do NOT return overrides for `req`, `res`, `url`, or `method` — the waterfall merge would overwrite them for subsequent plugins.
+
+```javascript
+hooks: {
+  async beforeRequest({ req, res, url, method, handled }) {
+    if (handled) return; // another plugin already handled it
+    if (url === '/api/plugin/my-endpoint' && method === 'GET') {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ hello: 'world' }));
+      return { handled: true };
+    }
+  },
+}
+```
+
 ### `httpsOptions` — Waterfall
 
 Triggered at server startup to obtain HTTPS certificate options. If the returned object contains `pfx` or `cert`, the server starts in HTTPS mode; otherwise it falls back to HTTP.
@@ -122,14 +154,27 @@ Triggered after the HTTP server starts successfully.
 | Property | Description |
 |----------|-------------|
 | **Type** | Parallel (concurrent notification) |
-| **Parameters** | `{ port, host, url, ip, token, protocol, httpServer }` |
+| **Parameters** | `{ port, host, url, ip, token, protocol, httpServer, pty }` |
 | **Returns** | Ignored |
 | **Timing** | After server binds to a port |
 
+The `pty` field provides PTY (terminal) API functions when running in CLI mode. It is `null` when not in CLI mode (e.g., SDK mode).
+
+| `pty` method | Signature | Description |
+|-------------|-----------|-------------|
+| `writeToPty(data)` | `(string) → boolean` | Write data to the PTY stdin. Returns `true` if written. |
+| `writeToPtySequential(chunks, onComplete, opts)` | `(string[], Function, object) → void` | Send chunks sequentially with delays. |
+| `getPtyState()` | `() → { running, exitCode }` | Get current PTY process state. |
+| `getOutputBuffer()` | `() → string` | Get accumulated PTY output (max 200KB). |
+| `onPtyData(cb)` | `(Function) → Function` | Register listener for PTY output. Returns unsubscribe function. |
+
 ```javascript
 hooks: {
-  async serverStarted({ port, host, url, ip, token, protocol, httpServer }) {
+  async serverStarted({ port, host, url, ip, token, protocol, httpServer, pty }) {
     console.error(`[my-plugin] Server is running at ${url}`);
+    if (pty) {
+      console.error(`[my-plugin] PTY state:`, pty.getPtyState());
+    }
   },
 }
 ```

--- a/docs/plugins.zh.md
+++ b/docs/plugins.zh.md
@@ -68,15 +68,50 @@ export default {
 
 | Hook 名称 | 类型 | 参数 | 返回值 | 触发时机 |
 |-----------|------|------|--------|---------|
+| `beforeRequest` | waterfall | `{ req, res, url, method, parsedUrl, handled }` | `{ handled: true }` 短路请求 | token 验证后、路由分发前 |
 | `httpsOptions` | waterfall | `{}` | `{ pfx, passphrase }` 或 `{ cert, key }` | 服务器创建前 |
 | `localUrl` | waterfall | `{ url, ip, port, token }` | `{ url }` | 客户端请求局域网地址时 |
-| `serverStarted` | parallel | `{ port, host, url, ip, token, protocol, httpServer }` | 忽略 | 服务器启动成功后 |
+| `serverStarted` | parallel | `{ port, host, url, ip, token, protocol, httpServer, pty }` | 忽略 | 服务器启动成功后 |
 | `serverStopping` | parallel | `{}` | 忽略 | 服务器关闭前 |
 | `onNewEntry` | parallel | `entry` (JSONL 日志条目对象) | 忽略 | 检测到新的 JSONL 日志条目时 |
 
 ---
 
 ## Hook 详解
+
+### `beforeRequest` — 拦截 HTTP 请求
+
+**类型：Waterfall（串行管道）**
+
+每个 HTTP 请求经过 token 认证后、路由分发前触发。允许插件拦截并处理自定义 API 端点。
+
+**参数说明：**
+
+| 参数 | 类型 | 说明 |
+|------|------|------|
+| `req` | `IncomingMessage` | Node.js 请求对象 |
+| `res` | `ServerResponse` | Node.js 响应对象 |
+| `url` | `string` | 请求路径（如 `/api/plugin/my-endpoint`） |
+| `method` | `string` | HTTP 方法（`GET`、`POST` 等） |
+| `parsedUrl` | `URL` | 完整的 URL 对象 |
+| `handled` | `boolean` | 初始为 `false`；插件写完响应后返回 `{ handled: true }` |
+
+**返回值：** 返回 `{ handled: true }` 表示已处理完成，cc-viewer 将跳过后续路由。
+
+> **重要：** 只应返回 `{ handled: true }`。不要在返回值中覆写 `req`、`res`、`url`、`method`——waterfall 合并机制会影响后续插件。
+
+```javascript
+hooks: {
+  async beforeRequest({ req, res, url, method, handled }) {
+    if (handled) return; // 其他插件已处理
+    if (url === '/api/plugin/my-endpoint' && method === 'GET') {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ hello: 'world' }));
+      return { handled: true };
+    }
+  },
+}
+```
 
 ### `httpsOptions` — 提供 HTTPS 证书
 
@@ -166,10 +201,23 @@ hooks: {
 
 服务器成功绑定端口后触发。适合用于发送通知、注册服务发现等。
 
+`pty` 字段在 CLI 模式下提供 PTY（终端）API 函数。非 CLI 模式（如 SDK 模式）下为 `null`。
+
+| `pty` 方法 | 签名 | 说明 |
+|-----------|------|------|
+| `writeToPty(data)` | `(string) → boolean` | 向 PTY stdin 写入数据。成功返回 `true`。 |
+| `writeToPtySequential(chunks, onComplete, opts)` | `(string[], Function, object) → void` | 按顺序发送多个 chunk。 |
+| `getPtyState()` | `() → { running, exitCode }` | 获取 PTY 进程状态。 |
+| `getOutputBuffer()` | `() → string` | 获取累积的 PTY 输出（最大 200KB）。 |
+| `onPtyData(cb)` | `(Function) → Function` | 注册 PTY 输出监听器。返回取消订阅函数。 |
+
 ```javascript
 hooks: {
-  async serverStarted({ port, host, url, ip, token, protocol, httpServer }) {
+  async serverStarted({ port, host, url, ip, token, protocol, httpServer, pty }) {
     console.error(`[my-plugin] 服务器运行在 ${url}`);
+    if (pty) {
+      console.error(`[my-plugin] PTY 状态:`, pty.getPtyState());
+    }
 
     // 示例：通知企业监控系统
     fetch('https://monitor.company.com/api/register', {

--- a/history.md
+++ b/history.md
@@ -185,6 +185,13 @@
 - Fix (其他 AppHeader SCU 白名单补齐 P1 修复合并): correctness-reviewer 指出 `toolChipGrid` 左 padding 16px 比 `.cacheSectionArrow` width 12px + gap 2px 多 2px，不严格对齐；改为 14px。另把 `mcpBody` 里 inline style `{flexDirection: 'column', alignItems: 'stretch'}` 抽成独立 `.toolChipGridVertical` 类，避免 inline style 与 module CSS 混用。
 - Hygiene (calibrationModel 配置更新): `src/config.json` 把手动校准主力模型下拉里的 `"Opus 4.6 (1M)"` / `opus-4.6-1m` 换成 `"Opus 4.7 (1M)"` / `opus-4.7-1m`，tokens 1M 保持不变。旧 `opus-4.6-1m` 偏好值在下拉里消失，用户需重新选。
 - Fix (MarkdownBlock 下载按钮斜向/垂直 hover 保护区): 用户反馈从对话气泡右下外侧沿垂直或斜向路径靠近右上角下载按钮时，鼠标轨迹落在"wrapper 外 + actionBar DOM 外"的空白里触发 wrapper 的 `mouseleave`，按钮 150ms 延迟兜底来不及就提前 fade out。在 `src/components/MarkdownBlock.jsx` 的 `.actionBar` 内 `.saveAsWrap` 前后各插入一个 `<div className={styles.hoverPad} aria-hidden="true" />`，CSS 新增 `.hoverPad` 用 `position: absolute`（脱离 flex 流，不占按钮位置使按钮保持 top:0 原位不下移）+ `left: 0` 对齐按钮左缘 + `width: 48px`（按钮 24px 向右溢出 24px 作水平 hover 桥）+ `height: 60px`（上下各给约 60px 竖向 hover 桥）；`.hoverPadTop` 用 `bottom: 100%` 贴按钮上方、`.hoverPadBottom` 用 `top: 100%` 贴按钮下方。actionBar 仅在 hovered=true 时 render，不干扰非激活气泡。
+## 1.6.184 (2026-04-23)
+
+- Feat (interaction hooks + HTTPS bridge support): add `onPermRequest`, `onAskRequest`, `onPlanRequest` waterfall hooks so plugins can intercept PTY-mode permission approvals, AskUserQuestion prompts, and plan approvals. Expand `serverStarted` hook context with `interactions` object exposing `getPendingPerms`, `resolvePerm`, `getPendingAsk`, `resolveAsk`, `resolveSdkApproval`. Add `CCVIEWER_PROTOCOL` env var injection in `pty-manager.js` so `ask-bridge.js` / `perm-bridge.js` auto-select `https` vs `http` client when `https-auto-cert` plugin is active. Both bridges gain `rejectUnauthorized: false` to accept self-signed certs.
+
+## 1.6.183 (2026-04-22)
+
+- Feat (plugin system: beforeRequest hook + bundled plugin loading): add a generic `beforeRequest` waterfall hook, allowing plugins to intercept HTTP requests after token auth. Expand `serverStarted` hook context with a `pty` field exposing PTY API functions (`writeToPty`, `getPtyState`, `getOutputBuffer`, `onPtyData`, `writeToPtySequential`) for CLI-mode plugins. Add bundled plugin loading support — plugins shipped in the package's `plugins/` directory are auto-loaded after user plugins, with user plugins taking priority by name.
 
 ## 1.6.182 (2026-04-20)
 

--- a/lib/ask-bridge.js
+++ b/lib/ask-bridge.js
@@ -26,7 +26,12 @@ import http from 'node:http';
 import https from 'node:https';
 
 const port = process.env.CCVIEWER_PORT;
-const isHttps = process.env.CCVIEWER_PROTOCOL === 'https';
+const rawProtocol = process.env.CCVIEWER_PROTOCOL;
+if (rawProtocol && rawProtocol !== 'http' && rawProtocol !== 'https') {
+  process.stderr.write(`ask-bridge: invalid CCVIEWER_PROTOCOL "${rawProtocol}" (expected "http" or "https")\n`);
+  process.exit(1);
+}
+const isHttps = rawProtocol === 'https';
 const httpClient = isHttps ? https : http;
 if (!port) {
   // cc-viewer not running — fall back to terminal UI silently (exit 0)

--- a/lib/ask-bridge.js
+++ b/lib/ask-bridge.js
@@ -23,8 +23,11 @@
 
 import { readFileSync } from 'node:fs';
 import http from 'node:http';
+import https from 'node:https';
 
 const port = process.env.CCVIEWER_PORT;
+const isHttps = process.env.CCVIEWER_PROTOCOL === 'https';
+const httpClient = isHttps ? https : http;
 if (!port) {
   // cc-viewer not running — fall back to terminal UI silently (exit 0)
   // exit(1) causes Claude Code to log "hook error" on every AskUserQuestion call
@@ -62,11 +65,12 @@ const TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
 function postToViewer() {
   return new Promise((resolve, reject) => {
     const body = JSON.stringify({ questions });
-    const req = http.request({
+    const req = httpClient.request({
       hostname: '127.0.0.1',
       port: Number(port),
       path: '/api/ask-hook',
       method: 'POST',
+      rejectUnauthorized: false, // allow self-signed certs
       headers: {
         'Content-Type': 'application/json',
         'Content-Length': Buffer.byteLength(body),

--- a/lib/perm-bridge.js
+++ b/lib/perm-bridge.js
@@ -16,7 +16,12 @@ import http from 'node:http';
 import https from 'node:https';
 
 const port = process.env.CCVIEWER_PORT;
-const isHttps = process.env.CCVIEWER_PROTOCOL === 'https';
+const rawProtocol = process.env.CCVIEWER_PROTOCOL;
+if (rawProtocol && rawProtocol !== 'http' && rawProtocol !== 'https') {
+  process.stderr.write(`perm-bridge: invalid CCVIEWER_PROTOCOL "${rawProtocol}" (expected "http" or "https")\n`);
+  process.exit(1);
+}
+const isHttps = rawProtocol === 'https';
 const httpClient = isHttps ? https : http;
 if (!port) {
   // cc-viewer not running — fall back to terminal UI silently (exit 0)

--- a/lib/perm-bridge.js
+++ b/lib/perm-bridge.js
@@ -13,8 +13,11 @@
 
 import { readFileSync } from 'node:fs';
 import http from 'node:http';
+import https from 'node:https';
 
 const port = process.env.CCVIEWER_PORT;
+const isHttps = process.env.CCVIEWER_PROTOCOL === 'https';
+const httpClient = isHttps ? https : http;
 if (!port) {
   // cc-viewer not running — fall back to terminal UI silently (exit 0)
   // exit(1) causes Claude Code to log "hook error" on every tool call
@@ -81,11 +84,12 @@ const TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
 function postToViewer() {
   return new Promise((resolve, reject) => {
     const body = JSON.stringify({ toolName, input: toolInput });
-    const req = http.request({
+    const req = httpClient.request({
       hostname: '127.0.0.1',
       port: Number(port),
       path: '/api/perm-hook',
       method: 'POST',
+      rejectUnauthorized: false, // allow self-signed certs
       headers: {
         'Content-Type': 'application/json',
         'Content-Length': Buffer.byteLength(body),

--- a/lib/plugin-loader.js
+++ b/lib/plugin-loader.js
@@ -1,5 +1,6 @@
 import { readdirSync, existsSync, readFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { LOG_DIR } from '../findcc.js';
 
 // 动态获取（LOG_DIR 可能在运行时被 setLogDir 修改）
@@ -9,6 +10,7 @@ const SHOULD_LOG = process.env.CCV_DEBUG_PLUGINS === '1';
 
 // Hook 类型定义
 const HOOK_TYPES = {
+  beforeRequest: 'waterfall',
   httpsOptions: 'waterfall',
   localUrl: 'waterfall',
   serverStarted: 'parallel',
@@ -24,8 +26,6 @@ let _plugins = [];
 export async function loadPlugins() {
   _plugins = [];
 
-  if (!existsSync(getPluginsDir())) return;
-
   // 读取 disabledPlugins 列表
   let disabledPlugins = [];
   try {
@@ -37,33 +37,59 @@ export async function loadPlugins() {
     }
   } catch { }
 
-  let files;
-  try {
-    files = readdirSync(getPluginsDir())
-      .filter(f => f.endsWith('.js') || f.endsWith('.mjs'))
-      .sort();
-  } catch {
-    return;
+  // Load user plugins from LOG_DIR/plugins/
+  if (existsSync(getPluginsDir())) {
+    let files;
+    try {
+      files = readdirSync(getPluginsDir())
+        .filter(f => f.endsWith('.js') || f.endsWith('.mjs'))
+        .sort();
+    } catch {
+      files = [];
+    }
+
+    for (const file of files) {
+      const filePath = join(getPluginsDir(), file);
+      try {
+        const mod = await import(`file://${filePath}`);
+        const plugin = mod.default || mod;
+        const name = plugin.name || file;
+
+        if (disabledPlugins.includes(name)) {
+          if (SHOULD_LOG) console.error(`[CC Viewer] Plugin "${name}" is disabled, skipping.`);
+          continue;
+        }
+
+        if (plugin.hooks && typeof plugin.hooks === 'object') {
+          _plugins.push({ name, hooks: plugin.hooks, file });
+          if (SHOULD_LOG) console.error(`[CC Viewer] Plugin loaded: ${name} (${file})`);
+        }
+      } catch (err) {
+        if (SHOULD_LOG) console.error(`[CC Viewer] Failed to load plugin "${file}":`, err.message);
+      }
+    }
   }
 
-  for (const file of files) {
-    const filePath = join(getPluginsDir(), file);
+  // Load bundled plugins from package's plugins/ directory (user plugins take priority)
+  const bundledDir = join(dirname(fileURLToPath(import.meta.url)), '..', 'plugins');
+  if (existsSync(bundledDir)) {
+    let bundledFiles;
     try {
-      const mod = await import(`file://${filePath}`);
-      const plugin = mod.default || mod;
-      const name = plugin.name || file;
-
-      if (disabledPlugins.includes(name)) {
-        if (SHOULD_LOG) console.error(`[CC Viewer] Plugin "${name}" is disabled, skipping.`);
-        continue;
+      bundledFiles = readdirSync(bundledDir).filter(f => f.endsWith('.js') || f.endsWith('.mjs')).sort();
+    } catch { bundledFiles = []; }
+    for (const file of bundledFiles) {
+      try {
+        const mod = await import(join(bundledDir, file));
+        const plugin = mod.default || mod;
+        const name = plugin.name || file.replace(/\.[cm]?js$/, '');
+        if (disabledPlugins.includes(name)) continue;
+        if (_plugins.some(p => p.name === name)) continue;
+        if (!plugin.hooks || typeof plugin.hooks !== 'object') continue;
+        _plugins.push({ name, hooks: plugin.hooks, file, source: 'bundled' });
+        if (SHOULD_LOG) console.error(`[CC Viewer] Bundled plugin loaded: ${name} (${file})`);
+      } catch (err) {
+        if (SHOULD_LOG) console.error(`[CC Viewer] Failed to load bundled plugin "${file}":`, err.message);
       }
-
-      if (plugin.hooks && typeof plugin.hooks === 'object') {
-        _plugins.push({ name, hooks: plugin.hooks, file });
-        if (SHOULD_LOG) console.error(`[CC Viewer] Plugin loaded: ${name} (${file})`);
-      }
-    } catch (err) {
-      if (SHOULD_LOG) console.error(`[CC Viewer] Failed to load plugin "${file}":`, err.message);
     }
   }
 }

--- a/lib/plugin-loader.js
+++ b/lib/plugin-loader.js
@@ -11,6 +11,9 @@ const SHOULD_LOG = process.env.CCV_DEBUG_PLUGINS === '1';
 // Hook 类型定义
 const HOOK_TYPES = {
   beforeRequest: 'waterfall',
+  onPermRequest: 'waterfall',
+  onAskRequest: 'waterfall',
+  onPlanRequest: 'waterfall',
   httpsOptions: 'waterfall',
   localUrl: 'waterfall',
   serverStarted: 'parallel',

--- a/lib/sdk-manager.js
+++ b/lib/sdk-manager.js
@@ -45,6 +45,7 @@ let _streamThrottleTimer = null;
 let _onEntry = null;
 let _onStreamingStatus = null;
 let _broadcastWs = null;
+let _runWaterfallHook = null;
 
 // Pending canUseTool promises: id → { resolve }
 const _pendingApprovals = new Map();
@@ -60,13 +61,14 @@ export function isSdkAvailable() {
  * Initialize SDK session.
  * Does NOT start a query — waits for the first user message via sendUserMessage().
  */
-export function initSdkSession(cwd, projectName, { onEntry, onStreamingStatus, broadcastWs, permissionMode }) {
+export function initSdkSession(cwd, projectName, { onEntry, onStreamingStatus, broadcastWs, permissionMode, runWaterfallHook }) {
   _cwd = cwd;
   _projectName = projectName;
   _onEntry = onEntry;
   _onStreamingStatus = onStreamingStatus;
   _broadcastWs = broadcastWs;
   _permissionMode = permissionMode || 'default';
+  _runWaterfallHook = runWaterfallHook || null;
   _resetFullState();
 }
 
@@ -343,6 +345,17 @@ async function _handleCanUseTool(toolName, input, options) {
   const id = options?.toolUseID || `sdk_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
 
   if (toolName === 'ExitPlanMode') {
+    if (_runWaterfallHook) {
+      try {
+        const hookResult = await _runWaterfallHook('onPlanRequest', { id, input, mode: 'sdk' });
+        if (hookResult.approve !== undefined) {
+          if (hookResult.approve === false) {
+            return { behavior: 'deny', message: hookResult.feedback || 'Plugin rejected the plan' };
+          }
+          return { behavior: 'allow', updatedInput: input };
+        }
+      } catch {}
+    }
     if (_broadcastWs) {
       _broadcastWs({ type: 'sdk-plan-pending', id, input });
     }
@@ -357,6 +370,14 @@ async function _handleCanUseTool(toolName, input, options) {
   }
 
   if (toolName === 'AskUserQuestion') {
+    if (_runWaterfallHook) {
+      try {
+        const hookResult = await _runWaterfallHook('onAskRequest', { id, questions: input.questions, mode: 'sdk' });
+        if (hookResult.answers) {
+          return { behavior: 'allow', updatedInput: { questions: input.questions, answers: hookResult.answers } };
+        }
+      } catch {}
+    }
     if (_broadcastWs) {
       _broadcastWs({ type: 'sdk-ask-pending', id, questions: input.questions });
     }
@@ -375,6 +396,19 @@ async function _handleCanUseTool(toolName, input, options) {
 
   // Permission approval for mutating tools
   const suggestions = options?.suggestions;
+  if (_runWaterfallHook) {
+    try {
+      const hookResult = await _runWaterfallHook('onPermRequest', { id, toolName, input, mode: 'sdk' });
+      if (hookResult.decision) {
+        if (hookResult.decision === 'deny') return { behavior: 'deny', message: 'Plugin denied' };
+        const response = { behavior: 'allow', updatedInput: input };
+        if (hookResult.allowSession && Array.isArray(suggestions) && suggestions.length > 0) {
+          response.updatedPermissions = suggestions;
+        }
+        return response;
+      }
+    } catch {}
+  }
   if (_broadcastWs) {
     _broadcastWs({ type: 'perm-hook-pending', id, toolName, input });
   }

--- a/lib/sdk-manager.js
+++ b/lib/sdk-manager.js
@@ -399,14 +399,17 @@ async function _handleCanUseTool(toolName, input, options) {
   if (_runWaterfallHook) {
     try {
       const hookResult = await _runWaterfallHook('onPermRequest', { id, toolName, input, mode: 'sdk' });
-      if (hookResult.decision) {
-        if (hookResult.decision === 'deny') return { behavior: 'deny', message: 'Plugin denied' };
+      if (hookResult.decision === 'allow') {
         const response = { behavior: 'allow', updatedInput: input };
         if (hookResult.allowSession && Array.isArray(suggestions) && suggestions.length > 0) {
           response.updatedPermissions = suggestions;
         }
         return response;
       }
+      if (hookResult.decision === 'deny') {
+        return { behavior: 'deny', message: 'Plugin denied' };
+      }
+      // unknown decision → fall through to normal approval flow
     } catch {}
   }
   if (_broadcastWs) {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "i18n.js",
     "findcc.js",
     "lib/",
+    "plugins/",
     "pty-manager.js",
     "workspace-registry.js",
     "concepts/"

--- a/pty-manager.js
+++ b/pty-manager.js
@@ -124,7 +124,7 @@ export function _markThinkingDisplayRejected(claudePath) {
   _thinkingDisplayRejectedPaths.add(claudePath);
 }
 
-export async function spawnClaude(proxyPort, cwd, extraArgs = [], claudePath = null, isNpmVersion = false, serverPort = null) {
+export async function spawnClaude(proxyPort, cwd, extraArgs = [], claudePath = null, isNpmVersion = false, serverPort = null, serverProtocol = 'http') {
   if (ptyProcess) {
     killPty();
   }
@@ -166,6 +166,7 @@ export async function spawnClaude(proxyPort, cwd, extraArgs = [], claudePath = n
     env.VISUAL = env.EDITOR;
     env.CCV_EDITOR_PORT = String(serverPort);
     env.CCVIEWER_PORT = String(serverPort); // For ask-hook bridge
+    env.CCVIEWER_PROTOCOL = serverProtocol; // For ask/perm-bridge (http vs https)
   }
 
   // 禁用 Claude Code CLI 的鼠标事件捕获，保住 xterm 面板原生文本选中（复制粘贴）。
@@ -238,7 +239,7 @@ export async function spawnClaude(proxyPort, cwd, extraArgs = [], claudePath = n
     if (hasContinue && exitCode !== 0 && outputBuffer.includes('No conversation found')) {
       console.error('[CC Viewer] -c failed (no conversation), retrying without -c');
       const retryArgs = extraArgs.filter(a => a !== '-c' && a !== '--continue');
-      spawnClaude(proxyPort, cwd, retryArgs, claudePath, isNpmVersion, serverPort);
+      spawnClaude(proxyPort, cwd, retryArgs, claudePath, isNpmVersion, serverPort, serverProtocol);
       return;
     }
 
@@ -254,7 +255,7 @@ export async function spawnClaude(proxyPort, cwd, extraArgs = [], claudePath = n
     if (flagRejected) {
       console.error('[CC Viewer] claude rejected --thinking-display, marking as unsupported and retrying without flag');
       _thinkingDisplayRejectedPaths.add(claudePath);
-      spawnClaude(proxyPort, cwd, extraArgs, claudePath, isNpmVersion, serverPort);
+      spawnClaude(proxyPort, cwd, extraArgs, claudePath, isNpmVersion, serverPort, serverProtocol);
       return;
     }
 

--- a/server.js
+++ b/server.js
@@ -284,6 +284,20 @@ async function handleRequest(req, res) {
     }
   }
 
+  // Plugin hook: intercept HTTP requests (after auth, before routing)
+  try {
+    const hookResult = await runWaterfallHook('beforeRequest', {
+      req, res, url, method, parsedUrl, handled: false,
+    });
+    if (hookResult.handled) return;
+  } catch (err) {
+    if (!res.headersSent) {
+      res.writeHead(500, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'Plugin error' }));
+    }
+    return;
+  }
+
   // User preferences API
   // File upload API — save to /tmp/cc-viewer-uploads/
   if (url === '/api/upload' && method === 'POST') {
@@ -3010,8 +3024,22 @@ export async function startViewer() {
             await setupTerminalWebSocket(currentServer);
           }
           // 通知插件服务器已启动
-          runParallelHook('serverStarted', { port, host: HOST, url, ip: getLocalIp(), token: ACCESS_TOKEN, protocol: serverProtocol, httpServer: currentServer })
-            .catch(err => console.error('[CC Viewer] Plugin serverStarted hook error:', err.message));
+          let ptyApi = null;
+          if (isCliMode) {
+            const pm = await import('./pty-manager.js');
+            ptyApi = {
+              writeToPty: pm.writeToPty,
+              writeToPtySequential: pm.writeToPtySequential,
+              getPtyState: pm.getPtyState,
+              getOutputBuffer: pm.getOutputBuffer,
+              onPtyData: pm.onPtyData,
+            };
+          }
+          await runParallelHook('serverStarted', {
+            port, host: HOST, url, ip: getLocalIp(),
+            token: ACCESS_TOKEN, protocol: serverProtocol,
+            httpServer: currentServer, pty: ptyApi,
+          });
           resolve(server);
         });
 

--- a/server.js
+++ b/server.js
@@ -3098,7 +3098,7 @@ export async function startViewer() {
                 }
                 return true;
               },
-              resolveSdkApproval: _sdkResolveApproval,
+              resolveSdkApproval: (...args) => _sdkResolveApproval?.(...args),
             },
           });
           resolve(server);

--- a/server.js
+++ b/server.js
@@ -710,7 +710,7 @@ async function handleRequest(req, res) {
         if (proxyPort) {
           const { spawnClaude } = await import('./pty-manager.js');
           const mergedArgs = [..._workspaceClaudeArgs, ...(Array.isArray(launchExtraArgs) ? launchExtraArgs : [])];
-          await spawnClaude(parseInt(proxyPort), wsPath, mergedArgs, _workspaceClaudePath, _workspaceIsNpmVersion, actualPort);
+          await spawnClaude(parseInt(proxyPort), wsPath, mergedArgs, _workspaceClaudePath, _workspaceIsNpmVersion, actualPort, serverProtocol);
         }
 
         _workspaceLaunched = true;
@@ -1941,7 +1941,7 @@ async function handleRequest(req, res) {
         return;
       }
     });
-    req.on('end', () => {
+    req.on('end', async () => {
       try {
         const { questions } = JSON.parse(body);
         if (!Array.isArray(questions) || questions.length === 0) {
@@ -1962,6 +1962,17 @@ async function handleRequest(req, res) {
         }
 
         const HOOK_TIMEOUT = 5 * 60 * 1000; // 5 minutes
+
+        // Plugin hook: let plugins answer questions directly
+        try {
+          const hookResult = await runWaterfallHook('onAskRequest', { id: `ask_${Date.now()}`, questions, mode: 'hook' });
+          if (hookResult.answers) {
+            res.writeHead(200, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ answers: hookResult.answers }));
+            return;
+          }
+        } catch {}
+
         const timer = setTimeout(() => {
           if (pendingAskHook && pendingAskHook.res === res) {
             pendingAskHook = null;
@@ -2025,7 +2036,7 @@ async function handleRequest(req, res) {
         return;
       }
     });
-    req.on('end', () => {
+    req.on('end', async () => {
       try {
         const { toolName, input } = JSON.parse(body);
         if (!toolName) {
@@ -2047,6 +2058,17 @@ async function handleRequest(req, res) {
 
         const HOOK_TIMEOUT = 5 * 60 * 1000;
         const id = `perm_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+
+        // Plugin hook: let plugins handle permission requests directly
+        try {
+          const hookResult = await runWaterfallHook('onPermRequest', { id, toolName, input, mode: 'hook' });
+          if (hookResult.decision) {
+            res.writeHead(200, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ decision: hookResult.decision }));
+            return;
+          }
+        } catch {}
+
         const timer = setTimeout(() => {
           const entry = pendingPermHooks.get(id);
           if (entry) {
@@ -3039,6 +3061,45 @@ export async function startViewer() {
             port, host: HOST, url, ip: getLocalIp(),
             token: ACCESS_TOKEN, protocol: serverProtocol,
             httpServer: currentServer, pty: ptyApi,
+            interactions: {
+              getPendingPerms: () => [...pendingPermHooks.entries()].map(([id, e]) => ({ id, toolName: e.toolName, input: e.input, createdAt: e.createdAt })),
+              resolvePerm: (id, decision, allowSession) => {
+                const entry = pendingPermHooks.get(id);
+                if (!entry) return false;
+                clearTimeout(entry.timer);
+                pendingPermHooks.delete(id);
+                try {
+                  if (!entry.res.headersSent) {
+                    entry.res.writeHead(200, { 'Content-Type': 'application/json' });
+                    entry.res.end(JSON.stringify({ decision }));
+                  }
+                } catch {}
+                if (terminalWss) {
+                  const rmsg = JSON.stringify({ type: 'perm-hook-resolved', id });
+                  terminalWss.clients.forEach((c) => { if (c.readyState === 1) try { c.send(rmsg); } catch {} });
+                }
+                return true;
+              },
+              getPendingAsk: () => pendingAskHook ? { questions: pendingAskHook.questions, createdAt: pendingAskHook.createdAt } : null,
+              resolveAsk: (answers) => {
+                if (!pendingAskHook) return false;
+                const { res: hookRes, timer } = pendingAskHook;
+                clearTimeout(timer);
+                pendingAskHook = null;
+                try {
+                  if (!hookRes.headersSent) {
+                    hookRes.writeHead(200, { 'Content-Type': 'application/json' });
+                    hookRes.end(JSON.stringify({ answers }));
+                  }
+                } catch {}
+                if (terminalWss) {
+                  const rmsg = JSON.stringify({ type: 'ask-hook-resolved' });
+                  terminalWss.clients.forEach((c) => { if (c.readyState === 1) try { c.send(rmsg); } catch {} });
+                }
+                return true;
+              },
+              resolveSdkApproval: _sdkResolveApproval,
+            },
           });
           resolve(server);
         });

--- a/test/plugin-loader.test.js
+++ b/test/plugin-loader.test.js
@@ -415,3 +415,80 @@ describe('getPluginsInfo', () => {
     }
   });
 });
+
+// ─── beforeRequest waterfall hook ───
+
+describe('beforeRequest waterfall hook', () => {
+  beforeEach(() => {
+    mkdirSync(PLUGINS_DIR, { recursive: true });
+  });
+  afterEach(async () => {
+    cleanup();
+    await loadPlugins();
+  });
+
+  it('returns handled:true when plugin sets it', async () => {
+    writePlugin('test-br-handle.js', `
+      export default {
+        name: 'br-handle',
+        hooks: {
+          beforeRequest({ url }) {
+            if (url === '/api/plugin/test') return { handled: true };
+          }
+        }
+      };
+    `);
+    await loadPlugins();
+    const result = await runWaterfallHook('beforeRequest', {
+      req: {}, res: {}, url: '/api/plugin/test', method: 'GET', parsedUrl: {}, handled: false,
+    });
+    assert.equal(result.handled, true);
+  });
+
+  it('passes through handled:false when no plugin handles it', async () => {
+    writePlugin('test-br-noop.js', `
+      export default {
+        name: 'br-noop',
+        hooks: {
+          beforeRequest({ url }) {
+            if (url === '/api/plugin/other') return { handled: true };
+          }
+        }
+      };
+    `);
+    await loadPlugins();
+    const result = await runWaterfallHook('beforeRequest', {
+      req: {}, res: {}, url: '/api/something-else', method: 'GET', parsedUrl: {}, handled: false,
+    });
+    assert.equal(result.handled, false);
+  });
+
+  it('first plugin handled:true is visible to second plugin', async () => {
+    writePlugin('test-br-first.js', `
+      export default {
+        name: 'br-first',
+        hooks: {
+          beforeRequest({ url }) {
+            if (url === '/api/plugin/test') return { handled: true };
+          }
+        }
+      };
+    `);
+    writePlugin('test-br-second.js', `
+      let sawHandled = false;
+      export default {
+        name: 'br-second',
+        hooks: {
+          beforeRequest({ handled }) {
+            sawHandled = handled;
+          }
+        }
+      };
+    `);
+    await loadPlugins();
+    const result = await runWaterfallHook('beforeRequest', {
+      req: {}, res: {}, url: '/api/plugin/test', method: 'GET', parsedUrl: {}, handled: false,
+    });
+    assert.equal(result.handled, true);
+  });
+});

--- a/test/plugin-loader.test.js
+++ b/test/plugin-loader.test.js
@@ -492,3 +492,179 @@ describe('beforeRequest waterfall hook', () => {
     assert.equal(result.handled, true);
   });
 });
+
+// ─── onPermRequest waterfall hook ───
+
+describe('onPermRequest waterfall hook', () => {
+  beforeEach(() => {
+    mkdirSync(PLUGINS_DIR, { recursive: true });
+  });
+  afterEach(async () => {
+    cleanup();
+    await loadPlugins();
+  });
+
+  it('returns decision:allow from plugin', async () => {
+    writePlugin('test-perm-allow.js', `
+      export default {
+        name: 'perm-allow',
+        hooks: {
+          onPermRequest({ toolName }) {
+            if (toolName === 'Bash') return { decision: 'allow' };
+          }
+        }
+      };
+    `);
+    await loadPlugins();
+    const result = await runWaterfallHook('onPermRequest', { id: '1', toolName: 'Bash', input: {} });
+    assert.equal(result.decision, 'allow');
+  });
+
+  it('returns decision:deny from plugin', async () => {
+    writePlugin('test-perm-deny.js', `
+      export default {
+        name: 'perm-deny',
+        hooks: {
+          onPermRequest({ toolName }) {
+            if (toolName === 'Bash') return { decision: 'deny' };
+          }
+        }
+      };
+    `);
+    await loadPlugins();
+    const result = await runWaterfallHook('onPermRequest', { id: '1', toolName: 'Bash', input: {} });
+    assert.equal(result.decision, 'deny');
+  });
+
+  it('continues on plugin error and returns initial value', async () => {
+    writePlugin('test-perm-err.js', `
+      export default {
+        name: 'perm-err',
+        hooks: {
+          onPermRequest() { throw new Error('fail'); }
+        }
+      };
+    `);
+    writePlugin('test-perm-ok.js', `
+      export default {
+        name: 'perm-ok',
+        hooks: {
+          onPermRequest() { return { decision: 'allow' }; }
+        }
+      };
+    `);
+    await loadPlugins();
+    const result = await runWaterfallHook('onPermRequest', { id: '1', toolName: 'Bash', input: {} });
+    assert.equal(result.decision, 'allow');
+  });
+});
+
+// ─── onAskRequest waterfall hook ───
+
+describe('onAskRequest waterfall hook', () => {
+  beforeEach(() => {
+    mkdirSync(PLUGINS_DIR, { recursive: true });
+  });
+  afterEach(async () => {
+    cleanup();
+    await loadPlugins();
+  });
+
+  it('returns answers from plugin', async () => {
+    writePlugin('test-ask-answers.js', `
+      export default {
+        name: 'ask-answers',
+        hooks: {
+          onAskRequest({ questions }) {
+            const answers = {};
+            for (const q of questions) answers[q.question] = q.options[0].label;
+            return { answers };
+          }
+        }
+      };
+    `);
+    await loadPlugins();
+    const questions = [{ question: 'Color?', header: 'Color', multiSelect: false, options: [{ label: 'Red' }] }];
+    const result = await runWaterfallHook('onAskRequest', { id: '1', questions });
+    assert.ok(result.answers, 'should have answers');
+    assert.equal(result.answers['Color?'], 'Red');
+  });
+
+  it('continues on plugin error and returns initial value', async () => {
+    writePlugin('test-ask-err.js', `
+      export default {
+        name: 'ask-err',
+        hooks: {
+          onAskRequest() { throw new Error('fail'); }
+        }
+      };
+    `);
+    await loadPlugins();
+    const questions = [{ question: 'Q?', header: 'Q', multiSelect: false, options: [{ label: 'A' }] }];
+    const result = await runWaterfallHook('onAskRequest', { id: '1', questions });
+    assert.ok(!result.answers, 'erroring plugin should not produce answers');
+  });
+});
+
+// ─── onPlanRequest waterfall hook ───
+
+describe('onPlanRequest waterfall hook', () => {
+  beforeEach(() => {
+    mkdirSync(PLUGINS_DIR, { recursive: true });
+  });
+  afterEach(async () => {
+    cleanup();
+    await loadPlugins();
+  });
+
+  it('returns approve:true from plugin', async () => {
+    writePlugin('test-plan-approve.js', `
+      export default {
+        name: 'plan-approve',
+        hooks: {
+          onPlanRequest() { return { approve: true }; }
+        }
+      };
+    `);
+    await loadPlugins();
+    const result = await runWaterfallHook('onPlanRequest', { id: '1', input: {}, mode: 'sdk' });
+    assert.equal(result.approve, true);
+  });
+
+  it('returns approve:false with feedback from plugin', async () => {
+    writePlugin('test-plan-reject.js', `
+      export default {
+        name: 'plan-reject',
+        hooks: {
+          onPlanRequest() { return { approve: false, feedback: 'Not good enough' }; }
+        }
+      };
+    `);
+    await loadPlugins();
+    const result = await runWaterfallHook('onPlanRequest', { id: '1', input: {}, mode: 'sdk' });
+    assert.equal(result.approve, false);
+    assert.equal(result.feedback, 'Not good enough');
+  });
+
+  it('continues on plugin error and returns initial value', async () => {
+    writePlugin('test-plan-err.js', `
+      export default {
+        name: 'plan-err',
+        hooks: {
+          onPlanRequest() { throw new Error('fail'); }
+        }
+      };
+    `);
+    writePlugin('test-plan-ok.js', `
+      export default {
+        name: 'plan-ok',
+        hooks: {
+          onPlanRequest() { return { approve: true }; }
+        }
+      };
+    `);
+    await loadPlugins();
+    const result = await runWaterfallHook('onPlanRequest', { id: '1', input: {}, mode: 'sdk' });
+    assert.equal(result.approve, true);
+  });
+});


### PR DESCRIPTION
## Summary
  - Add `beforeRequest` waterfall hook — plugins can intercept HTTP requests after token auth
  - Add `onPermRequest`, `onAskRequest`, `onPlanRequest` waterfall hooks — plugins can intercept PTY-mode permission approvals, AskUserQuestion prompts, and plan approvals
  - Expand `serverStarted` hook context with `pty` field (PTY API) and `interactions` object
  - Add bundled plugin loading — plugins in `plugins/` directory auto-load after user plugins
  - Add `CCVIEWER_PROTOCOL` env injection so ask-bridge / perm-bridge auto-select https vs http; both bridges support self-signed certs