### PR TITLE
fix: profile.json 路径跟随 --log-dir 而非硬编码 getClaudeConfigDir()

### DIFF
--- a/interceptor.js
+++ b/interceptor.js
@@ -11,7 +11,7 @@ import http from 'node:http';
 import { homedir } from 'node:os';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { dirname, join, basename } from 'node:path';
-import { LOG_DIR, getClaudeConfigDir } from './findcc.js';
+import { LOG_DIR } from './findcc.js';
 import { assembleStreamMessage, createStreamAssembler, cleanupTempFiles, findRecentLog, isAnthropicApiPath, isMainAgentRequest, rotateLogFile } from './lib/interceptor-core.js';
 
 
@@ -50,7 +50,8 @@ export let _cachedHaikuModel = null;
 //     兼容老数据：若文件里仍有 active 字段，读为"全局回退默认"；但本模块不再写它。
 //   <projectDir>/active-profile.json (每 workspace 独占): 仅存 { activeId }；
 //     切换 active 只影响当前 ccv 进程的 workspace，不污染其他实例。
-const PROFILE_PATH = join(getClaudeConfigDir(), 'cc-viewer', 'profile.json');
+// profile.json 存放在 LOG_DIR 下，受 --log-dir / CCV_LOG_DIR 影响
+const PROFILE_PATH = join(LOG_DIR, 'profile.json');
 let _activeProfile = null; // { id, name, baseURL?, apiKey?, models?, activeModel? }
 
 // 启动时捕获的原始配置（首次 API 请求时记录，不可变）

--- a/pty-manager.js
+++ b/pty-manager.js
@@ -1,4 +1,4 @@
-import { resolveNativePath } from './findcc.js';
+import { resolveNativePath, LOG_DIR } from './findcc.js';
 import { fileURLToPath } from 'node:url';
 import { join, dirname } from 'node:path';
 import { chmodSync, statSync } from 'node:fs';
@@ -144,6 +144,7 @@ export async function spawnClaude(proxyPort, cwd, extraArgs = [], claudePath = n
   const env = { ...process.env };
   env.ANTHROPIC_BASE_URL = `http://127.0.0.1:${proxyPort}`;
   env.CCV_PROXY_MODE = '1'; // 告诉 interceptor.js 不要再启动 server
+  env.CCV_LOG_DIR = LOG_DIR; // 让 fork 出的 Claude Code 进程找到同一份 profile.json 等资源
   // 剥离 cc-viewer 的内部短路开关，避免泄漏给 claude 子进程
   delete env.CCV_SKIP_THINKING_DISPLAY;
 


### PR DESCRIPTION
PROFILE_PATH 改用 LOG_DIR 作为父目录，使代理热切换配置与日志/项目数据保持一致的位置。 同时让 pty-manager 创建的子进程继承 CCV_LOG_DIR，确保 fork 出的 Claude Code 进程能 找到同一份 profile.json。