### PR TITLE
feat: 多终端支持 - Tab管理/改名/关闭确认/tmux仪表盘 

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -277,13 +277,20 @@ async function runProxyCommand(args) {
     });
 
     // 注入默认 --thinking-display summarized，仅对 claude 二进制（其他命令如 `ccv run -- sometool` 跳过）。
-    // 若 claude 不识别该 flag（老版本/fork）会 unknown option 崩溃——由 pty-manager.js::spawnClaude 的
+    // 若 claude 不识别该 flag（老版本/fork）会 unknown option 崩溃——由 terminal-manager.js::spawnClaude 的
     // onExit reactive retry 兜底；cli.js 这条路径是一次性子进程，没有 respawn 机会，用户需手动重试。
     // 可通过环境变量 CCV_SKIP_THINKING_DISPLAY=1 强制跳过。
     const isClaudeCmd = cmd === 'claude' || /[\\/]claude(\.exe)?$/.test(cmd);
     if (isClaudeCmd && process.env.CCV_SKIP_THINKING_DISPLAY !== '1') {
-      const { withDefaultThinkingDisplay } = await import('./pty-manager.js');
-      cmdArgs = withDefaultThinkingDisplay(cmdArgs);
+      // Inline withDefaultThinkingDisplay: inject --thinking-display summarized if not already present
+      if (Array.isArray(cmdArgs)) {
+        const hasFlag = cmdArgs.some(a =>
+          a === '--thinking-display' || (typeof a === 'string' && a.startsWith('--thinking-display='))
+        );
+        if (!hasFlag) {
+          cmdArgs = [...cmdArgs, '--thinking-display', 'summarized'];
+        }
+      }
     }
 
     cmdArgs.unshift(settingsJson);
@@ -364,12 +371,14 @@ async function runCliMode(extraClaudeArgs = [], cwd, noOpen = false) {
   const port = serverMod.getPort();
   const serverProtocol = serverMod.getProtocol();
 
-  // 3. 启动 PTY 中的 claude
-  const { spawnClaude, killPty } = await import('./pty-manager.js');
+  // 3. 创建默认终端 (纯 shell，用户自行启动 cfuse)
+  const { spawnShell, killAllTerminals, createTerminal } = await import('./terminal-manager.js');
+  const { homedir: getHome } = await import('os');
   try {
-    await spawnClaude(proxyPort, workingDir, extraClaudeArgs, claudePath, isNpmVersion, port, serverProtocol);
+    createTerminal('default', { cwd: getHome() });
+    await spawnShell('default');
   } catch (err) {
-    console.error('[CC Viewer] Failed to spawn Claude:', err.message);
+    console.error('[CC Viewer] Failed to spawn shell:', err.message);
     await serverMod.stopViewer();
     process.exit(1);
   }
@@ -395,7 +404,7 @@ async function runCliMode(extraClaudeArgs = [], cwd, noOpen = false) {
 
   // 5. 注册退出处理
   const cleanup = () => {
-    killPty();
+    killAllTerminals();
     serverMod.stopViewer().finally(() => process.exit());
   };
   process.on('SIGINT', cleanup);
@@ -548,9 +557,9 @@ async function runCliModeWorkspaceSelector(extraClaudeArgs = [], noOpen = false)
   }
 
   // 注册退出处理
-  const { killPty } = await import('./pty-manager.js');
+  const { killAllTerminals: killAll } = await import('./terminal-manager.js');
   const cleanup = () => {
-    killPty();
+    killAll();
     serverMod.stopViewer().finally(() => process.exit());
   };
   process.on('SIGINT', cleanup);

--- a/server.js
+++ b/server.js
@@ -1,7 +1,7 @@
 import { createServer } from 'node:http';
 import { createServer as createHttpsServer } from 'node:https';
 import { createConnection } from 'node:net';
-import { randomBytes } from 'node:crypto';
+import { randomBytes, timingSafeEqual } from 'node:crypto';
 import { readFileSync, writeFileSync, existsSync, watchFile, unwatchFile, statSync, readdirSync, renameSync, unlinkSync, rmSync, openSync, readSync, closeSync, realpathSync, mkdirSync, createReadStream, cpSync, copyFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join, extname, resolve, basename } from 'node:path';
@@ -72,19 +72,19 @@ const _maskProfiles = (data) => {
 };
 const _isMasked = (k) => typeof k === 'string' && /^\*{4}.{0,4}$/.test(k);
 
-// 获取 Claude 进程 PID（CLI 模式下从 pty-manager 获取）
-let _getPtyPidFn = null;
+// 获取 Claude 进程 PID（CLI 模式下从 terminal-manager 获取）
+let _getTerminalPidFn = null;
 function getClaudePid() {
   if (!isCliMode) return process.pid;
-  if (_getPtyPidFn) return _getPtyPidFn();
-  // lazy load 尚未完成，尝试同步获取（pty-manager 可能已被其他路径加载）
+  if (_getTerminalPidFn) return _getTerminalPidFn('default');
+  // lazy load 尚未完成，尝试同步获取（terminal-manager 可能已被其他路径加载）
   return null;
 }
 if (isCliMode) {
-  import('./pty-manager.js').then(m => {
-    _getPtyPidFn = m.getPtyPid;
+  import('./terminal-manager.js').then(m => {
+    _getTerminalPidFn = m.getTerminalPid;
   }).catch(err => {
-    console.error('[CC Viewer] Failed to load pty-manager for PID tracking:', err.message);
+    console.error('[CC Viewer] Failed to load terminal-manager for PID tracking:', err.message);
   });
 }
 
@@ -137,6 +137,16 @@ const _editorCleanupTimer = setInterval(() => {
   }
 }, 60000);
 _editorCleanupTimer.unref(); // Don't keep process alive for cleanup
+
+// Security helper: timing-safe token comparison to prevent timing attacks
+function safeTokenCompare(a, b) {
+  if (!a || !b) return false;
+  const bufA = Buffer.from(String(a));
+  const bufB = Buffer.from(String(b));
+  if (bufA.length !== bufB.length) return false;
+  return timingSafeEqual(bufA, bufB);
+}
+
 let terminalWss = null; // WebSocketServer reference for broadcasting
 let _writeToPty = null; // PTY write function reference (set by setupTerminalWebSocket)
 let _onPtyData = null;  // PTY data listener registration (set by setupTerminalWebSocket)
@@ -277,7 +287,7 @@ async function handleRequest(req, res) {
   const isStaticAsset = url.startsWith('/assets/') || url === '/favicon.ico';
   if (!isLocal && !isStaticAsset) {
     const urlToken = parsedUrl.searchParams.get('token');
-    if (urlToken !== ACCESS_TOKEN) {
+    if (!safeTokenCompare(urlToken, ACCESS_TOKEN)) {
       res.writeHead(403, { 'Content-Type': 'application/json' });
       res.end(JSON.stringify({ error: 'Forbidden: invalid token' }));
       return;
@@ -708,9 +718,10 @@ async function handleRequest(req, res) {
         // 启动 PTY
         const proxyPort = process.env.CCV_PROXY_PORT;
         if (proxyPort) {
-          const { spawnClaude } = await import('./pty-manager.js');
+          const { spawnClaude, createTerminal } = await import('./terminal-manager.js');
+          createTerminal('default');
           const mergedArgs = [..._workspaceClaudeArgs, ...(Array.isArray(launchExtraArgs) ? launchExtraArgs : [])];
-          await spawnClaude(parseInt(proxyPort), wsPath, mergedArgs, _workspaceClaudePath, _workspaceIsNpmVersion, actualPort, serverProtocol);
+          await spawnClaude('default', parseInt(proxyPort), wsPath, mergedArgs, _workspaceClaudePath, _workspaceIsNpmVersion, actualPort, serverProtocol);
         }
 
         _workspaceLaunched = true;
@@ -783,8 +794,8 @@ async function handleRequest(req, res) {
   }
 
   if (url === '/api/workspaces/stop' && method === 'POST') {
-    import('./pty-manager.js').then(({ killPty }) => {
-      killPty();
+    import('./terminal-manager.js').then(({ killTerminal }) => {
+      killTerminal('default');
 
       // 停止日志监听
       for (const logFile of getWatchedFiles().keys()) {
@@ -808,6 +819,199 @@ async function handleRequest(req, res) {
     }).catch(err => {
       res.writeHead(500, { 'Content-Type': 'application/json' });
       res.end(JSON.stringify({ error: err.message }));
+    });
+    return;
+  }
+
+  // ---- Multi-terminal REST API ----
+  if (url === '/api/terminals' && method === 'GET') {
+    import('./terminal-manager.js').then(({ listTerminals }) => {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(listTerminals()));
+    }).catch(err => {
+      res.writeHead(500, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: err.message }));
+    });
+    return;
+  }
+
+  if (url.startsWith('/api/terminals/') && url.endsWith('/preview') && method === 'GET') {
+    const parts = url.split('/');
+    // /api/terminals/:tid/preview
+    const tid = decodeURIComponent(parts[3]);
+    const linesParam = parsedUrl.searchParams.get('lines');
+    const lines = linesParam ? parseInt(linesParam, 10) : 5;
+    import('./terminal-manager.js').then(({ getTerminalBufferPreview }) => {
+      const preview = getTerminalBufferPreview(tid, lines);
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ tid, preview }));
+    }).catch(err => {
+      res.writeHead(500, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: err.message }));
+    });
+    return;
+  }
+
+  // Extract all URLs from terminal buffers (full buffer, handles line wrapping)
+  if (url === '/api/terminal-urls' && method === 'GET') {
+    const tidParam = parsedUrl.searchParams.get('tid'); // optional: specific terminal
+    import('./terminal-manager.js').then(({ listTerminals, getTerminalBuffer }) => {
+      const terminals = tidParam ? [{ tid: tidParam }] : listTerminals();
+      const allUrls = new Set();
+      for (const t of terminals) {
+        let buf = getTerminalBuffer(t.tid);
+        if (!buf) continue;
+        // Only scan last 5000 chars to get recent/relevant URLs
+        if (buf.length > 5000) buf = buf.slice(-5000);
+        // Strip ANSI escapes + DELETE line breaks (not replace with space)
+        // so wrapped URLs reassemble naturally
+        const clean = buf
+          .replace(/\x1b\[[0-9;]*[A-Za-z]/g, '')
+          .replace(/\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)/g, '')
+          .replace(/\x1b[()][AB012]/g, '')
+          .replace(/\x1b\[\?[0-9;]*[hl]/g, '')
+          .replace(/[\r\n]/g, '');
+        const matches = clean.match(/https?:\/\/[^\s<>"')\]]+/g);
+        if (matches) matches.forEach(u => allUrls.add(u));
+      }
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ urls: [...allUrls] }));
+    }).catch(err => {
+      res.writeHead(500, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: err.message }));
+    });
+    return;
+  }
+
+  // ─── Local tmux session discovery ───────────────────────────────
+  if (url === '/api/local-terminals' && method === 'GET') {
+    (async () => {
+      try {
+        // 1. Locate tmux binary
+        let tmuxPath;
+        try {
+          const { stdout } = await execFileAsync('which', ['tmux'], { timeout: 2000 });
+          tmuxPath = stdout.trim();
+        } catch {
+          // tmux not installed
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ tmux: { available: false, sessions: [] } }));
+          return;
+        }
+        if (!tmuxPath) {
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ tmux: { available: false, sessions: [] } }));
+          return;
+        }
+
+        // 2. List sessions
+        let sessionsRaw;
+        try {
+          const { stdout } = await execFileAsync(tmuxPath, [
+            'list-sessions', '-F',
+            '#{session_name}\t#{session_id}\t#{session_windows}\t#{session_attached}\t#{session_created}'
+          ], { timeout: 3000 });
+          sessionsRaw = stdout.trim();
+        } catch {
+          // No tmux server running or no sessions
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ tmux: { available: true, sessions: [] } }));
+          return;
+        }
+        if (!sessionsRaw) {
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ tmux: { available: true, sessions: [] } }));
+          return;
+        }
+
+        const sessions = [];
+        const sessionLines = sessionsRaw.split('\n').filter(Boolean);
+
+        for (const line of sessionLines) {
+          const [name, id, windows, attached, created] = line.split('\t');
+          if (!name) continue;
+
+          // 3. List panes for this session
+          let panes = [];
+          try {
+            const { stdout: panesOut } = await execFileAsync(tmuxPath, [
+              'list-panes', '-t', name, '-F',
+              '#{pane_index}\t#{pane_pid}\t#{pane_current_command}\t#{pane_current_path}\t#{pane_width}x#{pane_height}'
+            ], { timeout: 3000 });
+            const paneLines = panesOut.trim().split('\n').filter(Boolean);
+            for (const paneLine of paneLines) {
+              const [paneIndex, panePid, paneCmd, paneCwd, paneSize] = paneLine.split('\t');
+
+              // 4. Capture last 3 lines of each pane as preview
+              let preview = '';
+              try {
+                const { stdout: captureOut } = await execFileAsync(tmuxPath, [
+                  'capture-pane', '-t', `${name}:.${paneIndex}`, '-p'
+                ], { timeout: 3000 });
+                // Take last 3 non-empty lines
+                const allLines = captureOut.split('\n');
+                const nonEmpty = allLines.filter(l => l.trim().length > 0);
+                preview = nonEmpty.slice(-3).join('\n');
+              } catch {
+                // capture-pane may fail for some panes
+              }
+
+              panes.push({
+                index: parseInt(paneIndex, 10) || 0,
+                pid: parseInt(panePid, 10) || 0,
+                command: (paneCmd || '').trim(),
+                cwd: (paneCwd || '').trim(),
+                size: (paneSize || '').trim(),
+                preview
+              });
+            }
+          } catch {
+            // list-panes failed for this session
+          }
+
+          sessions.push({
+            name: (name || '').trim(),
+            id: (id || '').trim(),
+            windows: parseInt(windows, 10) || 0,
+            attached: attached === '1',
+            created: parseInt(created, 10) || 0,
+            panes
+          });
+        }
+
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ tmux: { available: true, sessions } }));
+      } catch (err) {
+        res.writeHead(500, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: err.message }));
+      }
+    })();
+    return;
+  }
+
+  // ─── Open tmux session in local Terminal.app (macOS only, localhost only) ──
+  if (url === '/api/open-local-terminal' && method === 'POST') {
+    // Security: token auth already enforced at HTTP layer
+    // This API runs osascript on the server (Mac), safe for authenticated remote clients
+    let body = '';
+    req.on('data', chunk => { body += chunk; });
+    req.on('end', async () => {
+      try {
+        const { sessionName } = JSON.parse(body);
+        if (!sessionName) throw new Error('sessionName required');
+        // Sanitize session name (alphanumeric, dash, underscore only)
+        if (!/^[a-zA-Z0-9_-]+$/.test(sessionName)) throw new Error('Invalid session name');
+
+        await execFileAsync('osascript', ['-e',
+          `tell application "Terminal" to do script "tmux attach-session -t ${sessionName}"`
+        ], { timeout: 5000 });
+
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ ok: true }));
+      } catch (err) {
+        res.writeHead(500, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: err.message }));
+      }
     });
     return;
   }
@@ -3066,13 +3270,13 @@ export async function startViewer() {
           // 通知插件服务器已启动
           let ptyApi = null;
           if (isCliMode) {
-            const pm = await import('./pty-manager.js');
+            const tm = await import('./terminal-manager.js');
             ptyApi = {
-              writeToPty: pm.writeToPty,
-              writeToPtySequential: pm.writeToPtySequential,
-              getPtyState: pm.getPtyState,
-              getOutputBuffer: pm.getOutputBuffer,
-              onPtyData: pm.onPtyData,
+              writeToPty: (data) => tm.writeToTerminal('default', data),
+              writeToPtySequential: (chunks, cb, opts) => tm.writeToTerminalSequential('default', chunks, cb, opts),
+              getPtyState: () => tm.getTerminalState('default') || { running: false },
+              getOutputBuffer: () => tm.getTerminalBuffer('default') || '',
+              onPtyData: (cb) => tm.onTerminalData('default', cb),
             };
           }
           await runParallelHook('serverStarted', {
@@ -3139,21 +3343,31 @@ export async function startViewer() {
 async function setupTerminalWebSocket(httpServer) {
   try {
     const { WebSocketServer } = await import('ws');
-    const { writeToPty, writeToPtySequential, resizePty, onPtyData, onPtyExit, getPtyState, getOutputBuffer, getCurrentWorkspace, spawnShell } = await import('./pty-manager.js');
-    _writeToPty = writeToPty;
-    _onPtyData = onPtyData;
+    const tm = await import('./terminal-manager.js');
+    const {
+      createTerminal, writeToTerminal, writeToTerminalSequential,
+      resizeTerminal, onTerminalData, onTerminalExit,
+      getTerminalState, getTerminalBuffer, listTerminals,
+      spawnClaude, spawnShell, killTerminal, removeTerminal,
+      renameTerminal, attachTmux, createTmuxSession,
+    } = tm;
+
+    // Backward compat: expose write/data for theme toggle via _writeToPty/_onPtyData
+    _writeToPty = (data) => writeToTerminal('default', data);
+    _onPtyData = (cb) => onTerminalData('default', cb);
+
     const wss = new WebSocketServer({ noServer: true });
     terminalWss = wss;
 
     // 多客户端共享 PTY 的尺寸冲突解决：
     // 移动端优先——只要有移动端在线，PTY 始终使用移动端尺寸，
     // PC 端的 resize 仅存储不生效，避免宽屏尺寸导致移动端乱码。
-    // PC 端显示窄输出但完全可读，移动端永远不会乱码。
     let activeWs = null;              // 当前活跃的 WebSocket 连接
     const clientSizes = new Map();    // ws → { cols, rows }
     const mobileClients = new Set();  // 移动端连接集合
+    // Track per-terminal data/exit listener cleanup functions per ws
+    const clientListenerCleanups = new Map(); // ws → Map<tid, { removeData, removeExit }>
 
-    // 找到一个在线的移动端并返回其尺寸
     const getMobileSize = () => {
       for (const mws of mobileClients) {
         if (mws.readyState === 1) {
@@ -3164,9 +3378,63 @@ async function setupTerminalWebSocket(httpServer) {
       return null;
     };
 
+    // Subscribe a WS client to a terminal's data/exit events
+    const subscribeToTerminal = (ws, tid) => {
+      let cleanups = clientListenerCleanups.get(ws);
+      if (!cleanups) { cleanups = new Map(); clientListenerCleanups.set(ws, cleanups); }
+      if (cleanups.has(tid)) return; // already subscribed
+
+      const removeData = onTerminalData(tid, (data) => {
+        if (ws.readyState === 1) {
+          ws.send(JSON.stringify({ type: 'data', tid, data }));
+        }
+      });
+      const removeExit = onTerminalExit(tid, (exitCode) => {
+        if (ws.readyState === 1) {
+          ws.send(JSON.stringify({ type: 'exit', tid, exitCode }));
+        }
+      });
+      cleanups.set(tid, { removeData, removeExit });
+    };
+
+    // Unsubscribe a WS client from a terminal
+    const unsubscribeFromTerminal = (ws, tid) => {
+      const cleanups = clientListenerCleanups.get(ws);
+      if (cleanups) {
+        const fns = cleanups.get(tid);
+        if (fns) { fns.removeData(); fns.removeExit(); cleanups.delete(tid); }
+      }
+    };
+
+    // Cleanup all subscriptions for a WS client
+    const cleanupClient = (ws) => {
+      const cleanups = clientListenerCleanups.get(ws);
+      if (cleanups) {
+        for (const { removeData, removeExit } of cleanups.values()) {
+          removeData(); removeExit();
+        }
+        cleanups.clear();
+      }
+      clientListenerCleanups.delete(ws);
+      clientSizes.delete(ws);
+      mobileClients.delete(ws);
+    };
+
     httpServer.on('upgrade', (req, socket, head) => {
-      const pathname = new URL(req.url, `${serverProtocol}://${req.headers.host}`).pathname;
+      const upgradeUrl = new URL(req.url, `${serverProtocol}://${req.headers.host}`);
+      const pathname = upgradeUrl.pathname;
       if (pathname === '/ws/terminal') {
+        // Token auth for non-local connections on WebSocket upgrade
+        const remoteIp = req.socket.remoteAddress;
+        const isLocal = remoteIp === '127.0.0.1' || remoteIp === '::1' || remoteIp === '::ffff:127.0.0.1';
+        if (!isLocal) {
+          const urlToken = upgradeUrl.searchParams.get('token');
+          if (!safeTokenCompare(urlToken, ACCESS_TOKEN)) {
+            socket.write('HTTP/1.1 403 Forbidden\r\n\r\n');
+            socket.destroy();
+            return;
+          }
+        }
         wss.handleUpgrade(req, socket, head, (ws) => {
           wss.emit('connection', ws, req);
         });
@@ -3176,88 +3444,221 @@ async function setupTerminalWebSocket(httpServer) {
     });
 
     wss.on('connection', (ws) => {
-      // 发送当前 PTY 状态
-      const state = getPtyState();
-      ws.send(JSON.stringify({ type: 'state', ...state }));
+      // On connect, send the list of all terminals
+      const allTerminals = listTerminals();
+      ws.send(JSON.stringify({ type: 'terminal-list', terminals: allTerminals }));
 
-      // 发送历史输出缓冲
-      const buffer = getOutputBuffer();
-      if (buffer) {
-        ws.send(JSON.stringify({ type: 'data', data: buffer }));
+      // Auto-subscribe to 'default' terminal for backward compatibility
+      const defaultState = getTerminalState('default');
+      if (defaultState) {
+        ws.send(JSON.stringify({ type: 'state', tid: 'default', ...defaultState }));
+        const defaultBuffer = getTerminalBuffer('default');
+        if (defaultBuffer) {
+          ws.send(JSON.stringify({ type: 'data', tid: 'default', data: defaultBuffer }));
+        }
+        subscribeToTerminal(ws, 'default');
       }
 
-      // PTY 输出 → WebSocket
-      const removeDataListener = onPtyData((data) => {
-        if (ws.readyState === 1) {
-          ws.send(JSON.stringify({ type: 'data', data }));
-        }
-      });
-
-      // PTY 退出 → WebSocket
-      const removeExitListener = onPtyExit((exitCode) => {
-        if (ws.readyState === 1) {
-          ws.send(JSON.stringify({ type: 'exit', exitCode }));
-        }
-      });
-
-      // WebSocket → PTY
+      // WebSocket message handler (with multi-terminal routing)
       ws.on('message', async (raw) => {
         try {
           const msg = JSON.parse(raw.toString());
+          // Route tid: default to 'default' for backward compat
+          const tid = msg.tid || 'default';
+
           if (msg.type === 'input') {
-            // PTY 已退出时，自动 spawn 交互式 shell
-            const state = getPtyState();
-            if (!state.running) {
-              try {
-                await spawnShell();
-              } catch {}
+            const state = getTerminalState(tid);
+            if (state && !state.running) {
+              try { await spawnShell(tid); } catch {}
             }
-            // 发送 input 的客户端成为活跃客户端
             if (activeWs !== ws) {
               activeWs = ws;
-              // 切换活跃客户端时，如果有移动端在线则保持移动端尺寸，
-              // 否则切换到新活跃客户端的尺寸
               const mSize = getMobileSize();
               if (mSize) {
-                resizePty(mSize.cols, mSize.rows);
+                resizeTerminal(tid, mSize.cols, mSize.rows);
               } else {
                 const size = clientSizes.get(ws);
                 if (size) {
-                  resizePty(size.cols, size.rows);
+                  resizeTerminal(tid, size.cols, size.rows);
                 }
               }
             }
-            // 拦截连续 Ctrl+C：2秒内连按2次则阻止并提醒，避免误退出 CLI
+            // 拦截连续 Ctrl+C：2秒内连按2次则阻止并提醒
             if (msg.data === '\x03') {
               const now = Date.now();
               if (!ws._ctrlCLastTime) ws._ctrlCLastTime = 0;
               if (now - ws._ctrlCLastTime < 2000) {
                 ws._ctrlCLastTime = 0;
                 try { ws.send(JSON.stringify({ type: 'toast', message: t('ui.terminal.ctrlCBlocked') })); } catch {}
-                // 不发送第二次 Ctrl+C 到 PTY
               } else {
                 ws._ctrlCLastTime = now;
-                writeToPty(msg.data);
+                writeToTerminal(tid, msg.data);
               }
             } else {
-              writeToPty(msg.data);
+              writeToTerminal(tid, msg.data);
             }
           } else if (msg.type === 'input-sequential') {
-            // Programmatic sequential input: send chunks one by one, waiting for PTY ACK
-            const state = getPtyState();
-            if (!state.running) {
-              try { await spawnShell(); } catch {}
+            const state = getTerminalState(tid);
+            if (state && !state.running) {
+              try { await spawnShell(tid); } catch {}
             }
             const chunks = msg.chunks;
             if (Array.isArray(chunks) && chunks.length > 0) {
-              writeToPtySequential(chunks, (ok) => {
+              writeToTerminalSequential(tid, chunks, (ok) => {
                 try {
-                  ws.send(JSON.stringify({ type: 'input-sequential-done', ok }));
+                  ws.send(JSON.stringify({ type: 'input-sequential-done', tid, ok }));
                 } catch {}
               }, { settleMs: msg.settleMs || 150 });
             }
+
+          // ---- Multi-terminal management messages ----
+          } else if (msg.type === 'terminal-create') {
+            try {
+              const defaultCwd = homedir();
+              let spawnCwd = defaultCwd;
+              if (msg.cwd) {
+                try {
+                  const resolved = realpathSync(msg.cwd);
+                  const cwdStat = statSync(resolved);
+                  if (!cwdStat.isDirectory()) throw new Error('Not a directory');
+                  spawnCwd = resolved;
+                } catch (cwdErr) {
+                  ws.send(JSON.stringify({ type: 'error', message: `Invalid cwd: ${msg.cwd}` }));
+                  return;
+                }
+              }
+              const termLabel = msg.label || spawnCwd.split('/').pop() || msg.tid;
+              createTerminal(msg.tid, { label: termLabel, cwd: spawnCwd });
+              subscribeToTerminal(ws, msg.tid);
+              // Spawn an interactive shell (plain shell, no auto-commands)
+              try {
+                await spawnShell(msg.tid);
+              } catch {}
+              // Broadcast terminal-created event
+              const createdMsg = JSON.stringify({ type: 'terminal-created', tid: msg.tid, cwd: spawnCwd });
+              wss.clients.forEach((c) => {
+                if (c.readyState === 1) try { c.send(createdMsg); } catch {}
+              });
+              // Broadcast updated terminal list
+              const updated = listTerminals();
+              const listMsg = JSON.stringify({ type: 'terminal-list', terminals: updated });
+              wss.clients.forEach((c) => {
+                if (c.readyState === 1) try { c.send(listMsg); } catch {}
+              });
+            } catch (err) {
+              ws.send(JSON.stringify({ type: 'terminal-error', tid: msg.tid, error: err.message }));
+            }
+          } else if (msg.type === 'terminal-attach-tmux') {
+            try {
+              const attachTid = msg.tid || `tmux-${Date.now()}`;
+              const tmuxTarget = msg.session; // tmux session name
+              const readOnly = msg.readOnly || false;
+
+              // Create a new CCV terminal slot for this attach
+              createTerminal(attachTid, { label: `tmux: ${tmuxTarget}`, cwd: null });
+              subscribeToTerminal(ws, attachTid);
+
+              const ok = await attachTmux(attachTid, tmuxTarget, readOnly);
+              if (!ok) {
+                // Remove the slot if attach failed
+                removeTerminal(attachTid);
+                ws.send(JSON.stringify({ type: 'terminal-error', tid: attachTid, error: `Failed to attach to tmux session: ${tmuxTarget}` }));
+              } else {
+                // Broadcast terminal-created event
+                const createdMsg = JSON.stringify({ type: 'terminal-created', tid: attachTid, cwd: '' });
+                wss.clients.forEach((c) => {
+                  if (c.readyState === 1) try { c.send(createdMsg); } catch {}
+                });
+              }
+
+              // Broadcast updated terminal list
+              const updated = listTerminals();
+              const listMsg = JSON.stringify({ type: 'terminal-list', terminals: updated });
+              wss.clients.forEach((c) => {
+                if (c.readyState === 1) try { c.send(listMsg); } catch {}
+              });
+            } catch (err) {
+              ws.send(JSON.stringify({ type: 'error', message: err.message }));
+            }
+          } else if (msg.type === 'terminal-create-tmux') {
+            try {
+              const sessionName = msg.sessionName || `ccv-${Date.now()}`;
+              const tmuxTid = `tmux-${Date.now()}-${Math.random().toString(36).slice(2,6)}`;
+              const cwd = msg.cwd || homedir();
+
+              createTerminal(tmuxTid, { label: `tmux: ${sessionName}`, cwd });
+              subscribeToTerminal(ws, tmuxTid);
+
+              const ok = await createTmuxSession(tmuxTid, sessionName, cwd);
+              if (!ok) {
+                removeTerminal(tmuxTid);
+                ws.send(JSON.stringify({ type: 'terminal-error', tid: tmuxTid, message: `Failed to create tmux session: ${sessionName}` }));
+              } else {
+                // Notify all clients: new tmux session created (PC auto-detect)
+                const notifyMsg = JSON.stringify({ type: 'tmux-session-created', sessionName, cwd, tid: tmuxTid });
+                wss.clients.forEach((c) => {
+                  if (c.readyState === 1) try { c.send(notifyMsg); } catch {}
+                });
+                // Server-side: auto-open Terminal.app with tmux attach (macOS only)
+                if (process.platform === 'darwin' && /^[a-zA-Z0-9_-]+$/.test(sessionName)) {
+                  try {
+                    const { execFile: ef } = await import('node:child_process');
+                    ef('osascript', ['-e', `tell application "Terminal" to do script "tmux attach-session -t ${sessionName}"`], { timeout: 5000 }, () => {});
+                  } catch {}
+                }
+              }
+
+              // Broadcast updated terminal list
+              const updated = listTerminals();
+              const listMsg = JSON.stringify({ type: 'terminal-list', terminals: updated });
+              wss.clients.forEach((c) => {
+                if (c.readyState === 1) try { c.send(listMsg); } catch {}
+              });
+            } catch (err) {
+              ws.send(JSON.stringify({ type: 'terminal-error', message: err.message }));
+            }
+          } else if (msg.type === 'terminal-close') {
+            // Broadcast terminal-closed event before cleanup
+            const closedMsg = JSON.stringify({ type: 'terminal-closed', tid: msg.tid });
+            wss.clients.forEach((c) => {
+              if (c.readyState === 1) try { c.send(closedMsg); } catch {}
+            });
+            wss.clients.forEach((c) => { unsubscribeFromTerminal(c, msg.tid); });
+            removeTerminal(msg.tid);
+            const updated = listTerminals();
+            const listMsg = JSON.stringify({ type: 'terminal-list', terminals: updated });
+            wss.clients.forEach((c) => {
+              if (c.readyState === 1) try { c.send(listMsg); } catch {}
+            });
+          } else if (msg.type === 'terminal-subscribe') {
+            const st = getTerminalState(msg.tid);
+            if (st) {
+              subscribeToTerminal(ws, msg.tid);
+              ws.send(JSON.stringify({ type: 'state', tid: msg.tid, ...st }));
+              const subBuffer = getTerminalBuffer(msg.tid);
+              if (subBuffer) {
+                ws.send(JSON.stringify({ type: 'data', tid: msg.tid, data: subBuffer }));
+              }
+            } else {
+              ws.send(JSON.stringify({ type: 'terminal-error', tid: msg.tid, error: 'Terminal not found' }));
+            }
+          } else if (msg.type === 'terminal-unsubscribe') {
+            unsubscribeFromTerminal(ws, msg.tid);
+          } else if (msg.type === 'terminal-list') {
+            ws.send(JSON.stringify({ type: 'terminal-list', terminals: listTerminals() }));
+          } else if (msg.type === 'terminal-rename') {
+            const ok = renameTerminal(msg.tid, msg.label || msg.tid);
+            if (ok) {
+              // Broadcast updated terminal list to all clients
+              const updated = listTerminals();
+              const listMsg = JSON.stringify({ type: 'terminal-list', terminals: updated });
+              wss.clients.forEach((c) => {
+                if (c.readyState === 1) try { c.send(listMsg); } catch {}
+              });
+            }
+
+          // ---- Hook / SDK messages (terminal-agnostic) ----
           } else if (msg.type === 'ask-hook-answer') {
-            // Client answered AskUserQuestion via hook bridge
             let askAnswered = false;
             if (pendingAskHook) {
               const { res: hookRes, timer } = pendingAskHook;
@@ -3271,7 +3672,6 @@ async function setupTerminalWebSocket(httpServer) {
                 }
               } catch {}
             }
-            // Broadcast resolved to other clients so they clear their ask panel
             if (askAnswered && terminalWss) {
               const rmsg = JSON.stringify({ type: 'ask-hook-resolved' });
               terminalWss.clients.forEach((c) => {
@@ -3279,7 +3679,6 @@ async function setupTerminalWebSocket(httpServer) {
               });
             }
           } else if (msg.type === 'perm-hook-answer') {
-            // Permission approval — SDK mode (canUseTool) or PTY mode (hook bridge)
             let permAnswered = false;
             if (isSdkMode && _sdkResolveApproval && msg.id) {
               permAnswered = _sdkResolveApproval(msg.id, msg.allowSession ? { decision: msg.decision || 'allow', allowSession: true } : (msg.decision || 'deny'));
@@ -3297,7 +3696,6 @@ async function setupTerminalWebSocket(httpServer) {
                 }
               } catch {}
             }
-            // Broadcast resolved only when an answer was actually processed
             if (permAnswered && terminalWss) {
               const rmsg = JSON.stringify({ type: 'perm-hook-resolved', id: msg.id });
               terminalWss.clients.forEach((c) => {
@@ -3305,11 +3703,9 @@ async function setupTerminalWebSocket(httpServer) {
               });
             }
           } else if (msg.type === 'sdk-ask-answer') {
-            // AskUserQuestion answer in SDK mode — resolve canUseTool Promise
             if (_sdkResolveApproval && msg.id) {
               _sdkResolveApproval(msg.id, msg.answers);
             }
-            // Broadcast resolved to other clients
             if (msg.id && terminalWss) {
               const rmsg = JSON.stringify({ type: 'sdk-ask-resolved', id: msg.id });
               terminalWss.clients.forEach((c) => {
@@ -3317,11 +3713,9 @@ async function setupTerminalWebSocket(httpServer) {
               });
             }
           } else if (msg.type === 'sdk-plan-answer') {
-            // Plan approval in SDK mode
             if (_sdkResolveApproval) {
               _sdkResolveApproval(msg.id, { approve: msg.approve !== false, feedback: msg.feedback || '' });
             }
-            // Broadcast resolved to other clients
             if (terminalWss) {
               const rmsg = JSON.stringify({ type: 'sdk-plan-resolved', id: msg.id });
               terminalWss.clients.forEach((c) => {
@@ -3329,14 +3723,12 @@ async function setupTerminalWebSocket(httpServer) {
               });
             }
           } else if (msg.type === 'sdk-user-message') {
-            // User message in SDK mode — relay to sdk-manager
             if (_sdkSendUserMessage && msg.text) {
               _sdkSendUserMessage(msg.text).catch(err => {
                 console.error('[SDK] sendUserMessage error:', err.message);
               });
             }
           } else if (msg.type === 'image-remove-notify' || msg.type === 'image-upload-notify') {
-            // Security: only allow paths within upload directories, reject traversal
             const p = msg.path;
             if (terminalWss && p && !p.includes('..') && (
               p.startsWith('/tmp/cc-viewer-uploads/') || (p.includes('/cc-viewer/') && p.includes('/images/'))
@@ -3349,37 +3741,31 @@ async function setupTerminalWebSocket(httpServer) {
               });
             }
           } else if (msg.type === 'resize') {
-            // 存储该客户端的尺寸
             clientSizes.set(ws, { cols: msg.cols, rows: msg.rows });
             if (msg.mobile) mobileClients.add(ws);
-            // 移动端 resize 始终生效；PC 端仅在无移动端时生效
+            // Resize applies to the specified terminal (or 'default')
             if (msg.mobile) {
-              resizePty(msg.cols, msg.rows);
+              resizeTerminal(tid, msg.cols, msg.rows);
             } else if (mobileClients.size === 0 && (activeWs === ws || activeWs === null)) {
               activeWs = ws;
-              resizePty(msg.cols, msg.rows);
+              resizeTerminal(tid, msg.cols, msg.rows);
             }
           }
         } catch {}
       });
 
       ws.on('close', () => {
-        removeDataListener();
-        removeExitListener();
-        clientSizes.delete(ws);
-        mobileClients.delete(ws);
+        cleanupClient(ws);
         if (activeWs === ws) {
-          // 活跃客户端断开，将控制权交给剩余的某个客户端
           activeWs = null;
-          // 优先使用移动端尺寸，无移动端则用剩余客户端尺寸
           const mSize = getMobileSize();
           if (mSize) {
-            resizePty(mSize.cols, mSize.rows);
+            resizeTerminal('default', mSize.cols, mSize.rows);
           } else {
             for (const [remainWs, size] of clientSizes) {
               if (remainWs.readyState === 1) {
                 activeWs = remainWs;
-                resizePty(size.cols, size.rows);
+                resizeTerminal('default', size.cols, size.rows);
                 break;
               }
             }
@@ -3522,9 +3908,10 @@ if (!isWorkspaceMode) {
       setTimeout(async () => {
         let ptyRunning = false;
         try {
-          const { getPtyState } = await import('./pty-manager.js');
-          ptyRunning = getPtyState().running === true;
-        } catch { /* 未加载 pty-manager 或 import 失败 → 当作不 running */ }
+          const { getTerminalState } = await import('./terminal-manager.js');
+          const defState = getTerminalState('default');
+          ptyRunning = defState ? defState.running === true : false;
+        } catch { /* 未加载 terminal-manager 或 import 失败 → 当作不 running */ }
         const busy = clients.length > 0 || ptyRunning || _sdkResolveApproval !== null;
         try {
           const result = await checkAndUpdate({ busy, portRange: [START_PORT, MAX_PORT] });

--- a/src/Mobile.jsx
+++ b/src/Mobile.jsx
@@ -7,6 +7,8 @@ import { isMainAgent, isSystemText, classifyUserContent } from './utils/contentF
 import { getModelMaxTokens, getEffectiveModel } from './utils/helpers';
 import ChatView from './components/ChatView';
 import TerminalPanel, { uploadFileAndGetPath } from './components/TerminalPanel';
+import MultiTerminalView from './components/MultiTerminalView';
+import { TerminalProvider } from './components/TerminalContext';
 import ToolApprovalPanel from './components/ToolApprovalPanel';
 import MobileGitDiff from './components/MobileGitDiff';
 import MobileFileExplorer from './components/MobileFileExplorer';
@@ -553,14 +555,16 @@ class Mobile extends AppBase {
           )}
           {!mobileIsLocalLog && (
             <div className={`${styles.mobileChatOverlay} ${this.state.mobileTerminalVisible ? styles.mobileChatOverlayVisible : ''}`}>
-              <TerminalPanel
-                modelName={mobileModelName}
-                onFilePath={this._handleTerminalFilePath}
-                pendingImages={this.state.terminalPendingImages}
-                onRemovePendingImage={this._handleRemoveTerminalImage}
-                onClearPendingImages={this._handleClearTerminalImages}
-                onClearContextOptimistic={this.handleClearContextOptimistic}
-              />
+              <TerminalProvider>
+                <MultiTerminalView
+                  modelName={mobileModelName}
+                  onFilePath={this._handleTerminalFilePath}
+                  pendingImages={this.state.terminalPendingImages}
+                  onRemovePendingImage={this._handleRemoveTerminalImage}
+                  onClearPendingImages={this._handleClearTerminalImages}
+                  onClearContextOptimistic={this.handleClearContextOptimistic}
+                />
+              </TerminalProvider>
             </div>
           )}
           <div className={`${styles.mobileGitDiffOverlay} ${this.state.mobileGitDiffVisible ? styles.mobileGitDiffOverlayVisible : ''}`}>

--- a/src/components/ChatView.jsx
+++ b/src/components/ChatView.jsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { Empty, Typography, Divider, Spin, Popover, Modal, message } from 'antd';
 import ChatMessage from './ChatMessage';
 import TerminalPanel, { uploadFileAndGetPath } from './TerminalPanel';
+import MultiTerminalView from './MultiTerminalView';
+import { TerminalProvider } from './TerminalContext';
 import FileExplorer from './FileExplorer';
 import FileContentView from './FileContentView';
 import ImageViewer from './ImageViewer';
@@ -3456,26 +3458,30 @@ class ChatView extends React.Component {
             <>
               <div className={styles.vResizer} onMouseDown={this.handleSplitMouseDown} />
               <div className={styles.terminalPanelWrap} style={{ width: terminalWidth }}>
-                <TerminalPanel onEditorOpen={(sessionId, filePath) => {
-                  this.setState({
-                    editorSessionId: sessionId,
-                    editorFilePath: filePath,
-                    currentFile: filePath,
-                    currentGitDiff: null,
-                    scrollToLine: null,
-                    fileVersion: (this.state.fileVersion || 0) + 1,
-                  });
-                }} onFilePath={(path) => {
-                  // 加入 pendingImages，在终端 Enter 时统一注入 PTY
-                  this._addPendingImage(path, 'terminal');
-                }}
-                pendingImages={this.state.pendingImages}
-                onRemovePendingImage={this._removePendingImage}
-                onClearPendingImages={this._clearPendingImages}
-                modelName={this._reqScanCache?.modelName}
-                getChatScroller={() => this._getScrollContainer()}
-                onClearContextOptimistic={this.props.onClearContextOptimistic}
-                />
+                <TerminalProvider>
+                  <MultiTerminalView
+                    onEditorOpen={(sessionId, filePath) => {
+                      this.setState({
+                        editorSessionId: sessionId,
+                        editorFilePath: filePath,
+                        currentFile: filePath,
+                        currentGitDiff: null,
+                        scrollToLine: null,
+                        fileVersion: (this.state.fileVersion || 0) + 1,
+                      });
+                    }}
+                    onFilePath={(path) => {
+                      // 加入 pendingImages，在终端 Enter 时统一注入 PTY
+                      this._addPendingImage(path, 'terminal');
+                    }}
+                    pendingImages={this.state.pendingImages}
+                    onRemovePendingImage={this._removePendingImage}
+                    onClearPendingImages={this._clearPendingImages}
+                    modelName={this._reqScanCache?.modelName}
+                    getChatScroller={() => this._getScrollContainer()}
+                    onClearContextOptimistic={this.props.onClearContextOptimistic}
+                  />
+                </TerminalProvider>
               </div>
             </>
           )}

--- a/src/components/DashboardOverlay.jsx
+++ b/src/components/DashboardOverlay.jsx
@@ -1,0 +1,360 @@
+import React, { useState, useEffect, useRef, useCallback } from 'react';
+import { useTerminalContext } from './TerminalContext';
+import { apiUrl } from '../utils/apiUrl';
+import { t } from '../i18n';
+import styles from './DashboardOverlay.module.css';
+
+/** Strip ANSI escape sequences from terminal output */
+function stripAnsi(str) {
+  return str
+    .replace(/\x1b\[[0-9;]*[A-Za-z]/g, '')
+    .replace(/\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)/g, '')
+    .replace(/\x1b[()][AB012]/g, '')
+    .replace(/\x1b\[[\?]?[0-9;]*[hl]/g, '');
+}
+
+/**
+ * Pull-down dashboard overlay showing all terminal cards with live preview.
+ * Slides down from the top of the screen with CSS transform.
+ */
+export default function DashboardOverlay({ visible, onClose }) {
+  const { terminals, activeTid, switchTerminal, createTerminal, closeTerminal, attachTmux, createTmuxSession, openLocalTerminal } = useTerminalContext();
+  const [previews, setPreviews] = useState({}); // tid -> string (last 2 lines)
+  const [closeConfirmTid, setCloseConfirmTid] = useState(null);
+  const [localTerminals, setLocalTerminals] = useState(null); // { tmux: { available, sessions } }
+  const [agentExpanded, setAgentExpanded] = useState(false);
+  const [showNewTmux, setShowNewTmux] = useState(false);
+  const [newTmuxName, setNewTmuxName] = useState('');
+  const intervalRef = useRef(null);
+
+  // Detect PC vs mobile for "Open in Terminal.app" button visibility
+  const isPC = typeof window !== 'undefined'
+    && window.innerWidth > 768
+    && !/Mobile|iPhone|iPad|Android/i.test(navigator.userAgent);
+
+  // Fetch preview data from REST API when visible
+  const fetchPreviews = useCallback(async () => {
+    const tids = Array.from(terminals.keys());
+    if (tids.length === 0) return;
+
+    const results = {};
+    await Promise.all(
+      tids.map(async (tid) => {
+        try {
+          const res = await fetch(apiUrl(`/api/terminals/${tid}/preview?lines=2`));
+          if (res.ok) {
+            const data = await res.json();
+            results[tid] = data.preview || data.lines || '';
+          }
+        } catch {
+          // Silently fail for individual previews
+        }
+      })
+    );
+    setPreviews((prev) => ({ ...prev, ...results }));
+  }, [terminals]);
+
+  // Fetch local tmux sessions
+  const fetchLocalTerminals = useCallback(async () => {
+    try {
+      const res = await fetch(apiUrl('/api/local-terminals'));
+      if (res.ok) {
+        const data = await res.json();
+        setLocalTerminals(data);
+      }
+    } catch {
+      // Silently fail - local terminals are optional
+    }
+  }, []);
+
+  // Poll previews every 1s while visible; local terminals every 5s
+  const localIntervalRef = useRef(null);
+  useEffect(() => {
+    if (visible) {
+      fetchPreviews();
+      fetchLocalTerminals();
+      intervalRef.current = setInterval(fetchPreviews, 1000);
+      localIntervalRef.current = setInterval(fetchLocalTerminals, 5000);
+    } else {
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
+      }
+      if (localIntervalRef.current) {
+        clearInterval(localIntervalRef.current);
+        localIntervalRef.current = null;
+      }
+    }
+    return () => {
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
+      }
+      if (localIntervalRef.current) {
+        clearInterval(localIntervalRef.current);
+        localIntervalRef.current = null;
+      }
+    };
+  }, [visible, fetchPreviews, fetchLocalTerminals]);
+
+  const handleCardClick = useCallback((tid) => {
+    switchTerminal(tid);
+    onClose();
+  }, [switchTerminal, onClose]);
+
+  const handleCreate = useCallback(() => {
+    createTerminal();
+    onClose();
+  }, [createTerminal, onClose]);
+
+  const handleClose = useCallback((e, tid) => {
+    e.stopPropagation();
+    setCloseConfirmTid(tid);
+  }, []);
+
+  const handleConfirmClose = useCallback(() => {
+    if (closeConfirmTid) {
+      closeTerminal(closeConfirmTid);
+      setCloseConfirmTid(null);
+    }
+  }, [closeConfirmTid, closeTerminal]);
+
+  const handleCancelClose = useCallback(() => {
+    setCloseConfirmTid(null);
+  }, []);
+
+  const handleAttach = useCallback((sessionName, readOnly = false) => {
+    attachTmux(sessionName, readOnly);
+    onClose();
+  }, [attachTmux, onClose]);
+
+  const handleCreateTmux = useCallback(() => {
+    const name = newTmuxName.trim() || `ccv-${Date.now()}`;
+    createTmuxSession(name);
+    setShowNewTmux(false);
+    setNewTmuxName('');
+    onClose();
+  }, [newTmuxName, createTmuxSession, onClose]);
+
+  const handleOpenLocal = useCallback((sessionName) => {
+    openLocalTerminal(sessionName);
+  }, [openLocalTerminal]);
+
+  const terminalList = Array.from(terminals.values());
+  const tmux = localTerminals?.tmux;
+  const hasTmuxSessions = tmux?.available && tmux.sessions.length > 0;
+
+  // Agent session pattern: split sessions into user vs agent groups
+  const AGENT_PATTERN = /^(codex-|lb-|dispatch-|agent-|ce-|pair-|left-brain|right-brain|monitor-|eval-)/i;
+  const userSessions = hasTmuxSessions ? tmux.sessions.filter((s) => !AGENT_PATTERN.test(s.name)) : [];
+  const agentSessions = hasTmuxSessions ? tmux.sessions.filter((s) => AGENT_PATTERN.test(s.name)) : [];
+
+  const renderSessionCard = (session) => (
+    <div key={session.id} className={styles.tmuxCard}>
+      <div className={styles.cardHeader}>
+        <span className={`${styles.dot} ${session.attached ? styles.dotRunning : styles.dotExited}`} />
+        <span className={styles.cardTitle}>{session.name}</span>
+        <span className={styles.cardCwd}>
+          {session.windows} win{session.windows !== 1 ? 's' : ''} / {session.panes.length} pane{session.panes.length !== 1 ? 's' : ''}
+          {session.attached ? ' (attached)' : ''}
+        </span>
+        {/* Open in Terminal.app - works from any device since API runs on server */}
+        {(
+          <button
+            className={styles.openLocalBtn}
+            title="Open in Terminal.app"
+            onClick={(e) => { e.stopPropagation(); handleOpenLocal(session.name); }}
+          >
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round">
+              <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+              <polyline points="15 3 21 3 21 9" />
+              <line x1="10" y1="14" x2="21" y2="3" />
+            </svg>
+          </button>
+        )}
+        <button
+          className={styles.attachBtn}
+          title={session.attached ? 'Attach (session is also attached elsewhere)' : 'Attach to this tmux session'}
+          onClick={(e) => { e.stopPropagation(); handleAttach(session.name, false); }}
+        >
+          Attach
+        </button>
+        <button
+          className={styles.attachBtnReadOnly}
+          title="Attach read-only"
+          onClick={(e) => { e.stopPropagation(); handleAttach(session.name, true); }}
+        >
+          RO
+        </button>
+      </div>
+      {session.panes.map((pane) => (
+        <div key={pane.index} className={styles.tmuxPaneInfo}>
+          <span className={styles.tmuxPaneLabel}>
+            .{pane.index} {pane.command} <span className={styles.tmuxPaneCwd}>{pane.cwd}</span>
+          </span>
+          {pane.preview && (
+            <pre className={styles.tmuxPreview}>{stripAnsi(pane.preview)}</pre>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+
+  return (
+    <>
+      {/* Backdrop */}
+      {visible && <div className={styles.backdrop} onClick={onClose} />}
+      {/* Sliding panel */}
+      <div className={`${styles.overlay} ${visible ? styles.overlayVisible : ''}`}>
+        <div className={styles.header}>
+          <span className={styles.title}>{t('ui.terminal')} ({terminalList.length})</span>
+          <button className={styles.closeBtn} onClick={onClose}>
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+              <line x1="18" y1="6" x2="6" y2="18" />
+              <line x1="6" y1="6" x2="18" y2="18" />
+            </svg>
+          </button>
+        </div>
+        <div className={styles.cardList}>
+          {/* Local tmux sessions -- user sessions (always expanded) */}
+          {userSessions.length > 0 && (
+            <div className={styles.localSection}>
+              <div className={styles.localSectionTitle}>
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+                  <rect x="2" y="3" width="20" height="18" rx="2" />
+                  <line x1="2" y1="9" x2="22" y2="9" />
+                  <line x1="10" y1="9" x2="10" y2="21" />
+                </svg>
+                <span>tmux Sessions ({userSessions.length})</span>
+                <button
+                  className={styles.newTmuxBtn}
+                  onClick={() => setShowNewTmux((p) => !p)}
+                  title="Create new tmux session"
+                >
+                  + tmux
+                </button>
+              </div>
+              {showNewTmux && (
+                <div className={styles.newTmuxInputRow}>
+                  <input
+                    className={styles.newTmuxInput}
+                    type="text"
+                    placeholder="session name"
+                    value={newTmuxName}
+                    onChange={(e) => setNewTmuxName(e.target.value)}
+                    onKeyDown={(e) => { if (e.key === 'Enter') handleCreateTmux(); if (e.key === 'Escape') setShowNewTmux(false); }}
+                    autoFocus
+                  />
+                  <button className={styles.attachBtn} onClick={handleCreateTmux}>Create</button>
+                </div>
+              )}
+              {userSessions.map(renderSessionCard)}
+            </div>
+          )}
+          {/* Local tmux sessions -- agent sessions (collapsible) */}
+          {agentSessions.length > 0 && (
+            <div className={styles.localSection}>
+              <button
+                className={styles.agentSessionHeader}
+                onClick={() => setAgentExpanded((prev) => !prev)}
+              >
+                <svg
+                  width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round"
+                  style={{ transform: agentExpanded ? 'rotate(90deg)' : 'rotate(0deg)', transition: 'transform 0.2s' }}
+                >
+                  <polyline points="9 6 15 12 9 18" />
+                </svg>
+                <span>Agent Sessions</span>
+                <span className={styles.agentSessionCount}>{agentSessions.length}</span>
+              </button>
+              {agentExpanded && agentSessions.map(renderSessionCard)}
+            </div>
+          )}
+          {/* No tmux sessions at all */}
+          {tmux?.available && tmux.sessions.length === 0 && (
+            <div className={styles.localSection}>
+              <div className={styles.localSectionTitle}>
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+                  <rect x="2" y="3" width="20" height="18" rx="2" />
+                  <line x1="2" y1="9" x2="22" y2="9" />
+                  <line x1="10" y1="9" x2="10" y2="21" />
+                </svg>
+                <span>Local tmux Sessions</span>
+                <button
+                  className={styles.newTmuxBtn}
+                  onClick={() => setShowNewTmux((p) => !p)}
+                  title="Create new tmux session"
+                >
+                  + tmux
+                </button>
+              </div>
+              {showNewTmux && (
+                <div className={styles.newTmuxInputRow}>
+                  <input
+                    className={styles.newTmuxInput}
+                    type="text"
+                    placeholder="session name"
+                    value={newTmuxName}
+                    onChange={(e) => setNewTmuxName(e.target.value)}
+                    onKeyDown={(e) => { if (e.key === 'Enter') handleCreateTmux(); if (e.key === 'Escape') setShowNewTmux(false); }}
+                    autoFocus
+                  />
+                  <button className={styles.attachBtn} onClick={handleCreateTmux}>Create</button>
+                </div>
+              )}
+              {!showNewTmux && <div className={styles.tmuxEmpty}>No active tmux sessions found</div>}
+            </div>
+          )}
+          {/* Managed terminals */}
+          {terminalList.map((term) => {
+            const isActive = term.tid === activeTid;
+            const isExited = term.status === 'exited';
+            const preview = previews[term.tid] || '';
+            // Preview might be an array of lines or a string
+            const previewText = stripAnsi(Array.isArray(preview) ? preview.join('\n') : String(preview));
+            return (
+              <div
+                key={term.tid}
+                className={`${styles.card} ${isActive ? styles.cardActive : ''}`}
+                onClick={() => handleCardClick(term.tid)}
+              >
+                <div className={styles.cardHeader}>
+                  <span className={`${styles.dot} ${isExited ? styles.dotExited : styles.dotRunning}`} />
+                  <span className={styles.cardTitle}>{term.title || term.tid}</span>
+                  <span className={styles.cardCwd}>{term.cwd}</span>
+                  <button className={styles.cardClose} onClick={(e) => handleClose(e, term.tid)}>
+                    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round">
+                      <line x1="18" y1="6" x2="6" y2="18" />
+                      <line x1="6" y1="6" x2="18" y2="18" />
+                    </svg>
+                  </button>
+                </div>
+                <pre className={styles.cardPreview}>{previewText || '...'}</pre>
+              </div>
+            );
+          })}
+          {/* New terminal card */}
+          <button className={styles.newCard} onClick={handleCreate}>
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+              <line x1="12" y1="5" x2="12" y2="19" />
+              <line x1="5" y1="12" x2="19" y2="12" />
+            </svg>
+            <span>{t('ui.terminal.addItem')}</span>
+          </button>
+        </div>
+      </div>
+      {/* Close confirmation overlay */}
+      {closeConfirmTid && (
+        <div className={styles.confirmOverlay} onClick={handleCancelClose}>
+          <div className={styles.confirmCard} onClick={(e) => e.stopPropagation()}>
+            <p className={styles.confirmText}>Close this terminal? Process will be terminated.</p>
+            <div className={styles.confirmActions}>
+              <button className={styles.confirmCancel} onClick={handleCancelClose}>Cancel</button>
+              <button className={styles.confirmOk} onClick={handleConfirmClose}>Close</button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/components/DashboardOverlay.module.css
+++ b/src/components/DashboardOverlay.module.css
@@ -1,0 +1,480 @@
+.backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 899;
+  background: rgba(0, 0, 0, 0.4);
+  -webkit-backdrop-filter: blur(2px);
+  backdrop-filter: blur(2px);
+  /* Prevent iOS overscroll on the backdrop layer */
+  overscroll-behavior: none;
+  touch-action: none;
+}
+
+.overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 900;
+  max-height: 70vh;
+  max-height: 70dvh; /* iOS Safari dynamic viewport height */
+  background: rgba(26, 26, 26, 0.95);
+  -webkit-backdrop-filter: blur(12px);
+  backdrop-filter: blur(12px);
+  border-bottom: 1px solid var(--border-hover);
+  border-radius: 0 0 16px 16px;
+  transform: translateY(-100%);
+  transition: transform 0.3s ease;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  /* Prevent iOS rubber-band overscroll inside the dashboard panel */
+  overscroll-behavior: contain;
+}
+
+.overlayVisible {
+  transform: translateY(0);
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 16px 10px;
+  flex-shrink: 0;
+}
+
+.title {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.closeBtn {
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  border-radius: 6px;
+}
+
+.closeBtn:active {
+  background: var(--border-secondary);
+}
+
+.cardList {
+  flex: 1;
+  overflow-y: auto;
+  padding: 0 12px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  -webkit-overflow-scrolling: touch;
+}
+
+.card {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-secondary);
+  border-radius: 10px;
+  padding: 10px 12px;
+  cursor: pointer;
+  transition: border-color 0.15s, background 0.15s;
+  min-height: 62px;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.card:active {
+  background: var(--bg-surface);
+}
+
+.cardActive {
+  border-color: var(--color-primary);
+  background: rgba(59, 130, 246, 0.06);
+}
+
+.cardHeader {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 6px;
+}
+
+.dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.dotRunning {
+  background: #4ade80;
+  box-shadow: 0 0 4px rgba(74, 222, 128, 0.4);
+}
+
+.dotExited {
+  background: #666;
+}
+
+.cardTitle {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+
+.cardCwd {
+  flex: 1;
+  font-size: 11px;
+  color: var(--text-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  text-align: right;
+  min-width: 0;
+}
+
+.cardClose {
+  flex-shrink: 0;
+  width: 24px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  border-radius: 4px;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.cardClose:active {
+  background: rgba(239, 68, 68, 0.2);
+  color: #ef4444;
+}
+
+.cardPreview {
+  margin: 0;
+  padding: 0;
+  font-family: Menlo, Monaco, 'Courier New', monospace;
+  font-size: 10px;
+  line-height: 1.4;
+  color: var(--text-muted);
+  white-space: pre-wrap;
+  word-break: break-all;
+  overflow: hidden;
+  max-height: 28px;
+}
+
+.newCard {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  height: 52px;
+  background: none;
+  border: 1px dashed var(--border-secondary);
+  border-radius: 10px;
+  color: var(--text-muted);
+  font-size: 13px;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+  transition: border-color 0.15s, color 0.15s;
+}
+
+.newCard:active {
+  border-color: var(--color-primary);
+  color: var(--color-primary);
+}
+
+/* Close confirmation overlay */
+.confirmOverlay {
+  position: fixed;
+  inset: 0;
+  z-index: 910;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.confirmCard {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-hover);
+  border-radius: 12px;
+  padding: 20px 24px;
+  max-width: 300px;
+  text-align: center;
+}
+
+.confirmText {
+  color: var(--text-primary);
+  font-size: 14px;
+  margin: 0 0 16px;
+}
+
+.confirmActions {
+  display: flex;
+  gap: 12px;
+  justify-content: center;
+}
+
+.confirmCancel,
+.confirmOk {
+  padding: 8px 20px;
+  border-radius: 6px;
+  border: none;
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.confirmCancel {
+  background: var(--bg-container);
+  color: var(--text-secondary);
+  border: 1px solid var(--border-secondary);
+}
+
+.confirmOk {
+  background: #ef4444;
+  color: #fff;
+}
+
+/* ─── Local tmux sessions ──────────────────────────────────────── */
+
+.localSection {
+  margin-bottom: 8px;
+}
+
+.localSectionTitle {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  padding: 4px 4px 8px;
+}
+
+.tmuxCard {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-secondary);
+  border-radius: 10px;
+  padding: 10px 12px;
+  margin-bottom: 6px;
+  min-height: 52px;
+}
+
+.tmuxPaneInfo {
+  padding: 4px 0 2px 15px;
+  border-left: 2px solid var(--border-secondary);
+  margin-left: 3px;
+  margin-top: 4px;
+}
+
+.tmuxPaneLabel {
+  font-size: 11px;
+  color: var(--text-secondary);
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.tmuxPaneCwd {
+  color: var(--text-muted);
+  font-size: 10px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.tmuxPreview {
+  margin: 4px 0 0;
+  padding: 4px 6px;
+  font-family: Menlo, Monaco, 'Courier New', monospace;
+  font-size: 9px;
+  line-height: 1.35;
+  color: var(--text-muted);
+  background: rgba(0, 0, 0, 0.25);
+  border-radius: 4px;
+  white-space: pre-wrap;
+  word-break: break-all;
+  overflow: hidden;
+  max-height: 42px;
+}
+
+.tmuxEmpty {
+  font-size: 12px;
+  color: var(--text-muted);
+  text-align: center;
+  padding: 12px 0;
+}
+
+.attachBtn {
+  flex-shrink: 0;
+  padding: 3px 10px;
+  font-size: 11px;
+  border-radius: 4px;
+  border: 1px solid rgba(74, 222, 128, 0.4);
+  background: rgba(74, 222, 128, 0.1);
+  color: #4ade80;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+  transition: background 0.15s, border-color 0.15s;
+}
+
+.attachBtn:hover {
+  background: rgba(74, 222, 128, 0.2);
+  border-color: rgba(74, 222, 128, 0.6);
+}
+
+.attachBtn:active {
+  background: rgba(74, 222, 128, 0.3);
+}
+
+.attachBtnReadOnly {
+  flex-shrink: 0;
+  padding: 3px 8px;
+  font-size: 10px;
+  border-radius: 4px;
+  border: 1px solid var(--border-secondary);
+  background: var(--bg-container);
+  color: var(--text-muted);
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+  transition: background 0.15s, border-color 0.15s, color 0.15s;
+}
+
+.attachBtnReadOnly:hover {
+  border-color: var(--border-hover);
+  color: var(--text-secondary);
+}
+
+.attachBtnReadOnly:active {
+  background: var(--bg-surface);
+}
+
+/* Agent session collapsible group header */
+.agentSessionHeader {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  padding: 6px 4px 8px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.agentSessionHeader:hover {
+  color: var(--text-secondary);
+}
+
+.agentSessionCount {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 20px;
+  height: 18px;
+  padding: 0 6px;
+  font-size: 10px;
+  font-weight: 700;
+  border-radius: 9px;
+  background: rgba(99, 102, 241, 0.15);
+  color: #818cf8;
+  letter-spacing: 0;
+  text-transform: none;
+}
+
+/* ─── New tmux session button & input ────────────────────────────── */
+
+.newTmuxBtn {
+  margin-left: auto;
+  padding: 2px 8px;
+  font-size: 10px;
+  font-weight: 600;
+  border-radius: 4px;
+  border: 1px solid rgba(59, 130, 246, 0.4);
+  background: rgba(59, 130, 246, 0.1);
+  color: #60a5fa;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+  transition: background 0.15s, border-color 0.15s;
+  text-transform: none;
+  letter-spacing: 0;
+}
+
+.newTmuxBtn:hover {
+  background: rgba(59, 130, 246, 0.2);
+  border-color: rgba(59, 130, 246, 0.6);
+}
+
+.newTmuxBtn:active {
+  background: rgba(59, 130, 246, 0.3);
+}
+
+.newTmuxInputRow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 4px 8px;
+}
+
+.newTmuxInput {
+  flex: 1;
+  padding: 5px 8px;
+  font-size: 12px;
+  font-family: Menlo, Monaco, 'Courier New', monospace;
+  border-radius: 6px;
+  border: 1px solid var(--border-secondary);
+  background: var(--bg-container);
+  color: var(--text-primary);
+  outline: none;
+  transition: border-color 0.15s;
+}
+
+.newTmuxInput:focus {
+  border-color: rgba(59, 130, 246, 0.6);
+}
+
+/* ─── Open in Terminal.app button ────────────────────────────────── */
+
+.openLocalBtn {
+  flex-shrink: 0;
+  width: 26px;
+  height: 26px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 4px;
+  border: 1px solid rgba(59, 130, 246, 0.4);
+  background: rgba(59, 130, 246, 0.1);
+  color: #60a5fa;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+  transition: background 0.15s, border-color 0.15s;
+}
+
+.openLocalBtn:hover {
+  background: rgba(59, 130, 246, 0.2);
+  border-color: rgba(59, 130, 246, 0.6);
+}
+
+.openLocalBtn:active {
+  background: rgba(59, 130, 246, 0.3);
+}

--- a/src/components/MultiTerminalView.jsx
+++ b/src/components/MultiTerminalView.jsx
@@ -1,0 +1,194 @@
+import React, { Component } from 'react';
+import TerminalContext from './TerminalContext';
+import TerminalPanel from './TerminalPanel';
+import TerminalTabBar from './TerminalTabBar';
+import DashboardOverlay from './DashboardOverlay';
+import styles from './MultiTerminalView.module.css';
+
+/**
+ * Multi-terminal view wrapper.
+ *
+ * Manages multiple TerminalPanel instances. Each gets its own DOM container
+ * that is shown/hidden via CSS (display: none/block) to preserve xterm.js
+ * scrollback buffers. Shares a single WebSocket via TerminalContext.
+ *
+ * For backward compatibility: if the multi-terminal server protocol is not
+ * available (no terminal-list response), falls back to rendering a single
+ * TerminalPanel without tid (legacy mode).
+ */
+class MultiTerminalView extends Component {
+  static contextType = TerminalContext;
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      dashboardVisible: false,
+      // Track which terminals have been mounted (for lazy initialization)
+      mountedTids: new Set(),
+    };
+    this._containerRef = React.createRef();
+    this._wasVisible = false;
+  }
+
+  componentDidMount() {
+    // Ensure at least one terminal exists. Check after a short delay
+    // to let the context populate from server terminal-list response.
+    this._initTimer = setTimeout(() => {
+      const ctx = this.context;
+      if (ctx && ctx.terminals.size === 0) {
+        // No terminals from server -- fall back to single-terminal mode.
+        // The TerminalPanel component will connect with its own WebSocket.
+        this.setState({ legacyMode: true });
+      }
+    }, 1500);
+
+    // iOS Safari: xterm.js canvas inside a CSS-transformed parent may render
+    // blank. Detect when this component's container transitions from hidden
+    // (transform: translateX(100%)) to visible and trigger a window resize
+    // event so TerminalPanel re-fits the terminal.
+    this._visibilityObserver = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          const isVisible = entry.isIntersecting;
+          if (isVisible && !this._wasVisible) {
+            // Container just became visible -- trigger resize on next frame
+            // so xterm.js re-measures canvas dimensions.
+            requestAnimationFrame(() => {
+              window.dispatchEvent(new Event('resize'));
+            });
+          }
+          this._wasVisible = isVisible;
+        }
+      },
+      { threshold: 0.1 }
+    );
+    if (this._containerRef.current) {
+      this._visibilityObserver.observe(this._containerRef.current);
+    }
+  }
+
+  componentDidUpdate(prevProps, prevState) {
+    // Track mounted tids
+    const ctx = this.context;
+    if (ctx) {
+      const { activeTid, terminals } = ctx;
+      if (activeTid && !this.state.mountedTids.has(activeTid)) {
+        this.setState((prev) => {
+          const next = new Set(prev.mountedTids);
+          next.add(activeTid);
+          return { mountedTids: next };
+        });
+      }
+    }
+  }
+
+  componentWillUnmount() {
+    if (this._initTimer) clearTimeout(this._initTimer);
+    if (this._visibilityObserver) {
+      this._visibilityObserver.disconnect();
+    }
+  }
+
+  handleOpenDashboard = () => {
+    this.setState({ dashboardVisible: true });
+  };
+
+  handleCloseDashboard = () => {
+    this.setState({ dashboardVisible: false });
+  };
+
+  render() {
+    const { modelName, onFilePath, onEditorOpen, pendingImages, onRemovePendingImage, onClearPendingImages, getChatScroller, onClearContextOptimistic } = this.props;
+    const ctx = this.context;
+
+    // Legacy mode: no multi-terminal support from server
+    if (this.state.legacyMode || !ctx) {
+      return (
+        <div className={styles.container} ref={this._containerRef}>
+          <div className={styles.terminalArea}>
+            <TerminalPanel
+              modelName={modelName}
+              onFilePath={onFilePath}
+              onEditorOpen={onEditorOpen}
+              pendingImages={pendingImages}
+              onRemovePendingImage={onRemovePendingImage}
+              onClearPendingImages={onClearPendingImages}
+              getChatScroller={getChatScroller}
+              onClearContextOptimistic={onClearContextOptimistic}
+            />
+          </div>
+        </div>
+      );
+    }
+
+    const { terminals, activeTid } = ctx;
+    const terminalList = Array.from(terminals.values());
+
+    // If no terminals exist yet, show a single legacy TerminalPanel
+    // This handles the case where the new protocol is available but
+    // no terminals have been created yet.
+    if (terminalList.length === 0) {
+      return (
+        <div className={styles.container} ref={this._containerRef}>
+          <div className={styles.terminalArea}>
+            <TerminalPanel
+              modelName={modelName}
+              onFilePath={onFilePath}
+              onEditorOpen={onEditorOpen}
+              pendingImages={pendingImages}
+              onRemovePendingImage={onRemovePendingImage}
+              onClearPendingImages={onClearPendingImages}
+              getChatScroller={getChatScroller}
+              onClearContextOptimistic={onClearContextOptimistic}
+            />
+          </div>
+          <TerminalTabBar onOpenDashboard={this.handleOpenDashboard} />
+          <DashboardOverlay
+            visible={this.state.dashboardVisible}
+            onClose={this.handleCloseDashboard}
+          />
+        </div>
+      );
+    }
+
+    return (
+      <div className={styles.container} ref={this._containerRef}>
+        <div className={styles.terminalArea}>
+          {terminalList.map((term) => {
+            const isActive = term.tid === activeTid;
+            // Only mount terminals that have been active at least once
+            const isMounted = this.state.mountedTids.has(term.tid) || isActive;
+            if (!isMounted) return null;
+            return (
+              <div
+                key={term.tid}
+                className={styles.terminalPane}
+                style={{ display: isActive ? 'flex' : 'none' }}
+              >
+                <TerminalPanel
+                  tid={term.tid}
+                  modelName={modelName}
+                  onFilePath={onFilePath}
+                  onEditorOpen={onEditorOpen}
+                  pendingImages={isActive ? pendingImages : []}
+                  onRemovePendingImage={onRemovePendingImage}
+                  onClearPendingImages={onClearPendingImages}
+                  getChatScroller={getChatScroller}
+                  onClearContextOptimistic={onClearContextOptimistic}
+                  isActive={isActive}
+                />
+              </div>
+            );
+          })}
+        </div>
+        <TerminalTabBar onOpenDashboard={this.handleOpenDashboard} />
+        <DashboardOverlay
+          visible={this.state.dashboardVisible}
+          onClose={this.handleCloseDashboard}
+        />
+      </div>
+    );
+  }
+}
+
+export default MultiTerminalView;

--- a/src/components/MultiTerminalView.module.css
+++ b/src/components/MultiTerminalView.module.css
@@ -1,0 +1,57 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  width: 100%;
+  overflow: hidden;
+  min-height: 0; /* Allow flex shrinking in iOS Safari */
+}
+
+.terminalArea {
+  flex: 1;
+  position: relative;
+  overflow: hidden;
+  min-height: 0;
+}
+
+.terminalPane {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+/* ─── Mobile: ensure terminal container fills viewport properly ─── */
+@media (pointer: coarse), (max-width: 768px) {
+  .container {
+    /* On mobile, flex height: 100% may not resolve through transform'd ancestors.
+       Use absolute positioning as fallback to guarantee fill.
+       Do NOT set height: auto -- it overrides the height computed by inset: 0
+       and collapses the container to zero when children have no intrinsic height. */
+    position: absolute;
+    inset: 0;
+    /* Prevent iOS rubber-band overscroll from revealing black background */
+    background: var(--bg-base-alt);
+    overscroll-behavior: none;
+  }
+
+  .terminalArea {
+    /* Consistent background so pull-down never shows black */
+    background: var(--bg-base-alt);
+  }
+
+  /* On mobile, TerminalPanel sets touch-action: none on its container
+     which blocks all native touch scrolling. We cannot modify TerminalPanel,
+     but we can override touch-action on all descendants within .terminalArea
+     so the browser allows vertical panning to reach xterm's scroll handler.
+     Using a broad descendant selector since TerminalPanel uses CSS modules
+     (mangled class names). */
+  .terminalArea * {
+    touch-action: pan-y;
+  }
+
+  /* xterm.js viewport needs momentum scrolling on iOS */
+  .terminalArea :global(.xterm-viewport) {
+    -webkit-overflow-scrolling: touch;
+  }
+}

--- a/src/components/TerminalContext.jsx
+++ b/src/components/TerminalContext.jsx
@@ -1,0 +1,361 @@
+import React, { createContext, useContext, useState, useCallback, useRef, useEffect } from 'react';
+import { apiUrl } from '../utils/apiUrl';
+
+const TerminalContext = createContext(null);
+
+let _tidCounter = 0;
+function generateTid() {
+  _tidCounter += 1;
+  return `term-${Date.now()}-${_tidCounter}`;
+}
+
+export function TerminalProvider({ children }) {
+  // terminals: Map<tid, {tid, status, cwd, createdAt, title}>
+  const [terminals, setTerminals] = useState(new Map());
+  const [activeTid, setActiveTid] = useState(null);
+  const wsRef = useRef(null);
+  const dataListenersRef = useRef(new Map()); // tid -> callback(data)
+  const stateListenersRef = useRef(new Map()); // tid -> callback(msg)
+  const pendingSubscribes = useRef([]);
+
+  // Build WebSocket connection (shared across all terminals)
+  const getWs = useCallback(() => {
+    if (wsRef.current && wsRef.current.readyState === WebSocket.OPEN) {
+      return wsRef.current;
+    }
+    return null;
+  }, []);
+
+  const connectWs = useCallback(() => {
+    if (wsRef.current && (wsRef.current.readyState === WebSocket.OPEN || wsRef.current.readyState === WebSocket.CONNECTING)) {
+      return;
+    }
+    const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+    const urlParams = new URLSearchParams(window.location.search);
+    const token = urlParams.get('token');
+    const wsUrl = `${protocol}//${window.location.host}/ws/terminal${token ? `?token=${token}` : ''}`;
+    const ws = new WebSocket(wsUrl);
+
+    ws.onopen = () => {
+      // Request terminal list on connect
+      ws.send(JSON.stringify({ type: 'terminal-list' }));
+      // Re-subscribe to any pending terminals
+      for (const tid of pendingSubscribes.current) {
+        ws.send(JSON.stringify({ type: 'terminal-subscribe', tid }));
+      }
+      pendingSubscribes.current = [];
+      // Re-subscribe all active listeners (handles reconnect --
+      // server only auto-subscribes default, so non-default terminals
+      // would lose their data stream without this)
+      for (const tid of dataListenersRef.current.keys()) {
+        ws.send(JSON.stringify({ type: 'terminal-subscribe', tid }));
+      }
+    };
+
+    ws.onmessage = (event) => {
+      try {
+        const msg = JSON.parse(event.data);
+
+        if (msg.type === 'terminal-list') {
+          // Populate known terminals from server
+          const newMap = new Map();
+          if (Array.isArray(msg.terminals)) {
+            for (const t of msg.terminals) {
+              newMap.set(t.tid, {
+                tid: t.tid,
+                status: t.running === false ? 'exited' : 'running',
+                cwd: t.cwd || '',
+                createdAt: t.createdAt || Date.now(),
+                title: t.label || (t.cwd ? t.cwd.split('/').pop() : `Terminal`),
+              });
+            }
+          }
+          setTerminals(newMap);
+          // If no active terminal but we have terminals, pick the first
+          if (newMap.size > 0) {
+            setActiveTid((prev) => {
+              if (prev && newMap.has(prev)) return prev;
+              return newMap.keys().next().value;
+            });
+          }
+          return;
+        }
+
+        if (msg.type === 'terminal-created') {
+          setTerminals((prev) => {
+            const next = new Map(prev);
+            next.set(msg.tid, {
+              tid: msg.tid,
+              status: 'running',
+              cwd: msg.cwd || '',
+              createdAt: Date.now(),
+              title: msg.cwd ? msg.cwd.split('/').pop() : `Terminal`,
+            });
+            return next;
+          });
+          return;
+        }
+
+        if (msg.type === 'terminal-closed') {
+          setTerminals((prev) => {
+            const next = new Map(prev);
+            const existing = next.get(msg.tid);
+            if (existing) {
+              next.set(msg.tid, { ...existing, status: 'exited' });
+            }
+            return next;
+          });
+          return;
+        }
+
+        // tmux-session-created: server handles auto-open Terminal.app
+        if (msg.type === 'tmux-session-created') {
+          return;
+        }
+
+        // Handle terminal-error: rollback optimistic terminal creation
+        if (msg.type === 'terminal-error') {
+          setTerminals((prev) => {
+            const next = new Map(prev);
+            if (msg.tid && next.has(msg.tid)) {
+              next.delete(msg.tid);
+            }
+            return next;
+          });
+          // If the errored terminal was active, switch to another
+          setActiveTid((prevTid) => {
+            if (prevTid !== msg.tid) return prevTid;
+            // Pick another terminal
+            return null; // will be resolved by terminal-list update
+          });
+          return;
+        }
+
+        // Handle terminal-agnostic messages (no tid) before tid routing
+        if (msg.type === 'toast' || msg.type === 'editor-open') {
+          // Broadcast to all registered state listeners
+          for (const listener of stateListenersRef.current.values()) {
+            try { listener(msg); } catch {}
+          }
+          return;
+        }
+
+        // Route data/state/exit to specific terminal listeners
+        if (msg.tid) {
+          if (msg.type === 'data') {
+            const listener = dataListenersRef.current.get(msg.tid);
+            if (listener) listener(msg.data);
+          } else if (msg.type === 'state' || msg.type === 'exit') {
+            const listener = stateListenersRef.current.get(msg.tid);
+            if (listener) listener(msg);
+            if (msg.type === 'exit') {
+              setTerminals((prev) => {
+                const next = new Map(prev);
+                const existing = next.get(msg.tid);
+                if (existing) {
+                  next.set(msg.tid, { ...existing, status: 'exited' });
+                }
+                return next;
+              });
+            }
+          }
+        } else {
+          // Legacy single-terminal messages (no tid) -- route to active terminal
+          // This provides backward compatibility with the existing server
+          const tid = activeTidRef.current;
+          if (tid) {
+            if (msg.type === 'data') {
+              const listener = dataListenersRef.current.get(tid);
+              if (listener) listener(msg.data);
+            } else if (msg.type === 'state' || msg.type === 'exit') {
+              const listener = stateListenersRef.current.get(tid);
+              if (listener) listener(msg);
+            }
+          }
+        }
+      } catch { /* ignore parse errors */ }
+    };
+
+    ws.onclose = () => {
+      wsRef.current = null;
+      // Reconnect after delay
+      setTimeout(() => {
+        connectWs();
+      }, 2000);
+    };
+
+    wsRef.current = ws;
+  }, []);
+
+  // Keep a ref of activeTid for use in ws.onmessage callback
+  const activeTidRef = useRef(activeTid);
+  useEffect(() => {
+    activeTidRef.current = activeTid;
+  }, [activeTid]);
+
+  // Connect on mount
+  useEffect(() => {
+    connectWs();
+    return () => {
+      if (wsRef.current) {
+        wsRef.current.onclose = null;
+        wsRef.current.close();
+        wsRef.current = null;
+      }
+    };
+  }, [connectWs]);
+
+  const sendMessage = useCallback((msg) => {
+    const ws = wsRef.current;
+    if (ws && ws.readyState === WebSocket.OPEN) {
+      ws.send(JSON.stringify(msg));
+    }
+  }, []);
+
+  const createTerminal = useCallback((cwd) => {
+    const tid = generateTid();
+    sendMessage({ type: 'terminal-create', tid, cwd: cwd || '' });
+    // Optimistically add to local state
+    setTerminals((prev) => {
+      const next = new Map(prev);
+      next.set(tid, {
+        tid,
+        status: 'running',
+        cwd: cwd || '',
+        createdAt: Date.now(),
+        title: cwd ? cwd.split('/').pop() : `Terminal`,
+      });
+      return next;
+    });
+    setActiveTid(tid);
+    // Subscribe to this terminal's output
+    sendMessage({ type: 'terminal-subscribe', tid });
+    return tid;
+  }, [sendMessage]);
+
+  const closeTerminal = useCallback((tid) => {
+    sendMessage({ type: 'terminal-close', tid });
+    // Remove terminal and switch active if needed
+    setTerminals((prev) => {
+      const next = new Map(prev);
+      next.delete(tid);
+      // Also update activeTid based on the updated terminals map
+      setActiveTid((prevTid) => {
+        if (prevTid !== tid) return prevTid;
+        const keys = Array.from(next.keys());
+        return keys.length > 0 ? keys[keys.length - 1] : null;
+      });
+      return next;
+    });
+    // Cleanup listeners
+    dataListenersRef.current.delete(tid);
+    stateListenersRef.current.delete(tid);
+  }, [sendMessage]);
+
+  const switchTerminal = useCallback((tid) => {
+    setActiveTid(tid);
+  }, []);
+
+  const renameTerminal = useCallback((tid, newLabel) => {
+    if (!newLabel || !newLabel.trim()) return;
+    const label = newLabel.trim();
+    // Update local state immediately
+    setTerminals((prev) => {
+      const next = new Map(prev);
+      const existing = next.get(tid);
+      if (existing) {
+        next.set(tid, { ...existing, title: label });
+      }
+      return next;
+    });
+    // Send rename request to server
+    sendMessage({ type: 'terminal-rename', tid, label });
+  }, [sendMessage]);
+
+  const registerDataListener = useCallback((tid, callback) => {
+    dataListenersRef.current.set(tid, callback);
+    return () => dataListenersRef.current.delete(tid);
+  }, []);
+
+  const registerStateListener = useCallback((tid, callback) => {
+    stateListenersRef.current.set(tid, callback);
+    return () => stateListenersRef.current.delete(tid);
+  }, []);
+
+  const subscribeTerminal = useCallback((tid) => {
+    const ws = wsRef.current;
+    if (ws && ws.readyState === WebSocket.OPEN) {
+      ws.send(JSON.stringify({ type: 'terminal-subscribe', tid }));
+    } else {
+      pendingSubscribes.current.push(tid);
+    }
+  }, []);
+
+  const attachTmux = useCallback((sessionName, readOnly = false) => {
+    const tid = `tmux-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
+    sendMessage({ type: 'terminal-attach-tmux', tid, session: sessionName, readOnly });
+    // Optimistically add to local state
+    setTerminals((prev) => {
+      const next = new Map(prev);
+      next.set(tid, {
+        tid,
+        status: 'running',
+        cwd: '',
+        createdAt: Date.now(),
+        title: `tmux: ${sessionName}`,
+      });
+      return next;
+    });
+    setActiveTid(tid);
+    // Subscribe to this terminal's output
+    sendMessage({ type: 'terminal-subscribe', tid });
+    return tid;
+  }, [sendMessage]);
+
+  const createTmuxSession = useCallback((sessionName, cwd) => {
+    sendMessage({ type: 'terminal-create-tmux', sessionName, cwd });
+  }, [sendMessage]);
+
+  const openLocalTerminal = useCallback(async (sessionName) => {
+    try {
+      await fetch(apiUrl('/api/open-local-terminal'), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ sessionName }),
+      });
+    } catch { /* best-effort */ }
+  }, []);
+
+  const value = {
+    terminals,
+    activeTid,
+    createTerminal,
+    closeTerminal,
+    switchTerminal,
+    renameTerminal,
+    attachTmux,
+    createTmuxSession,
+    openLocalTerminal,
+    sendMessage,
+    getWs,
+    registerDataListener,
+    registerStateListener,
+    subscribeTerminal,
+  };
+
+  return (
+    <TerminalContext.Provider value={value}>
+      {children}
+    </TerminalContext.Provider>
+  );
+}
+
+export function useTerminalContext() {
+  const ctx = useContext(TerminalContext);
+  if (!ctx) {
+    throw new Error('useTerminalContext must be used within TerminalProvider');
+  }
+  return ctx;
+}
+
+export default TerminalContext;

--- a/src/components/TerminalPanel.jsx
+++ b/src/components/TerminalPanel.jsx
@@ -20,6 +20,7 @@ import CustomUltraplanEditModal from './CustomUltraplanEditModal';
 import ImageLightbox from './ImageLightbox';
 import ConfirmRemoveButton from './ConfirmRemoveButton';
 import { resizeImageIfNeeded } from '../utils/imageResize';
+import TerminalContext from './TerminalContext';
 
 const darkTerminalTheme = {
   background: '#0a0a0a', foreground: '#d4d4d4', cursor: '#0a0a0a',
@@ -109,6 +110,8 @@ export async function uploadFileAndGetPath(file) {
 }
 
 class TerminalPanel extends React.Component {
+  static contextType = TerminalContext;
+
   constructor(props) {
     super(props);
     this.containerRef = React.createRef();
@@ -117,6 +120,8 @@ class TerminalPanel extends React.Component {
     this.fitAddon = null;
     this.ws = null;
     this.resizeObserver = null;
+    // Whether this panel uses context-mediated WS (multi-terminal mode)
+    this._useContextWs = !!props.tid;
     this.state = {
       terminalFocused: false,
       agentTeamEnabled: false,
@@ -143,7 +148,11 @@ class TerminalPanel extends React.Component {
 
   componentDidMount() {
     this.initTerminal();
-    this.connectWebSocket();
+    if (this._useContextWs) {
+      this._connectViaContext();
+    } else {
+      this.connectWebSocket();
+    }
     this.setupResizeObserver();
     // 读取 claude settings 判断 Agent Team 是否可用
     fetch(apiUrl('/api/claude-settings')).then(r => r.json()).then(data => {
@@ -162,6 +171,21 @@ class TerminalPanel extends React.Component {
       }
     });
     this._themeObserver.observe(document.documentElement, { attributes: true, attributeFilter: ['data-theme'] });
+  }
+
+  componentDidUpdate(prevProps) {
+    // When terminal becomes active (switched to in multi-terminal mode), re-fit and focus
+    if (this.props.isActive && !prevProps.isActive) {
+      requestAnimationFrame(() => {
+        if (this.fitAddon && this.containerRef.current) {
+          try {
+            this.fitAddon.fit();
+            this.sendResize();
+          } catch {}
+        }
+        if (this.terminal) this.terminal.focus();
+      });
+    }
   }
 
   _loadPresetShortcuts() {
@@ -201,6 +225,9 @@ class TerminalPanel extends React.Component {
   }
 
   componentWillUnmount() {
+    // Cleanup context-mediated listeners
+    if (this._unregisterDataListener) this._unregisterDataListener();
+    if (this._unregisterStateListener) this._unregisterStateListener();
     if (this.terminal?.textarea) {
       this.terminal.textarea.removeEventListener('focus', this._handleTermFocus);
       this.terminal.textarea.removeEventListener('blur', this._handleTermBlur);
@@ -301,8 +328,10 @@ class TerminalPanel extends React.Component {
         // 后者被 Claude Code 当作 Enter 提交，于是"看起来换行没生效"。
         e.preventDefault();
         e.stopPropagation();
-        if (this.ws && this.ws.readyState === WebSocket.OPEN) {
-          this.ws.send(JSON.stringify({ type: 'input', data: '\x1b\r' }));
+        if (this._isWsReady()) {
+          const msg = { type: 'input', data: '\x1b\r' };
+          if (this.props.tid) msg.tid = this.props.tid;
+          this._sendWsMessage(msg);
         }
         return false;
       }
@@ -312,9 +341,11 @@ class TerminalPanel extends React.Component {
       if (e.type === 'keydown' && e.key === 'Enter' && !e.shiftKey && !e.ctrlKey && !e.metaKey) {
         const pending = this.props.pendingImages;
         const inAlternateScreen = this.terminal?.buffer?.active?.type === 'alternate';
-        if (pending?.length > 0 && !inAlternateScreen && this.ws?.readyState === WebSocket.OPEN) {
+        if (pending?.length > 0 && !inAlternateScreen && this._isWsReady()) {
           const paths = pending.map(img => `'${img.path.replace(/'/g, "'\\''")}'`).join(' ');
-          this.ws.send(JSON.stringify({ type: 'input', data: paths + ' ' }));
+          const inputMsg = { type: 'input', data: paths + ' ' };
+          if (this.props.tid) inputMsg.tid = this.props.tid;
+          this._sendWsMessage(inputMsg);
           this.props.onClearPendingImages?.();
           return false;
         }
@@ -340,8 +371,10 @@ class TerminalPanel extends React.Component {
     });
 
     this.terminal.onData((data) => {
-      if (this.ws && this.ws.readyState === WebSocket.OPEN) {
-        this.ws.send(JSON.stringify({ type: 'input', data }));
+      if (this._isWsReady()) {
+        const msg = { type: 'input', data };
+        if (this.props.tid) msg.tid = this.props.tid;
+        this._sendWsMessage(msg);
       }
     });
 
@@ -548,16 +581,85 @@ class TerminalPanel extends React.Component {
     };
   }
 
-  sendResize() {
-    if (this.ws && this.ws.readyState === WebSocket.OPEN && this.terminal) {
-      const msg = {
-        type: 'resize',
-        cols: this.terminal.cols,
-        rows: this.terminal.rows,
-      };
-      if (isMobile) msg.mobile = true;
+  /**
+   * Context-mediated connection: use TerminalContext's shared WebSocket
+   * instead of creating a separate one. Register data/state listeners
+   * that route only this terminal's data to the xterm instance.
+   */
+  _connectViaContext() {
+    const ctx = this.context;
+    if (!ctx) return;
+    const tid = this.props.tid;
+
+    // Register data listener -- receives only data for this tid
+    this._unregisterDataListener = ctx.registerDataListener(tid, (data) => {
+      this._throttledWrite(data);
+    });
+
+    // Register state listener -- receives state/exit for this tid
+    this._unregisterStateListener = ctx.registerStateListener(tid, (msg) => {
+      if (msg.type === 'exit') {
+        this._flushWrite();
+        this.terminal.write(`\r\n\x1b[33m${t('ui.terminal.exited', { code: msg.exitCode ?? '?' })}\x1b[0m\r\n`);
+        this.terminal.write(`\x1b[90m${t('ui.terminal.pressEnterForShell')}\x1b[0m\r\n`);
+      } else if (msg.type === 'state') {
+        if (!msg.running && msg.exitCode !== null) {
+          this._flushWrite();
+          this.terminal.write(`\x1b[33m${t('ui.terminal.exited', { code: msg.exitCode })}\x1b[0m\r\n`);
+          this.terminal.write(`\x1b[90m${t('ui.terminal.pressEnterForShell')}\x1b[0m\r\n`);
+        }
+      } else if (msg.type === 'toast') {
+        this._flushWrite();
+        this.terminal.write(`\r\n\x1b[33m\u26a0 ${msg.message}\x1b[0m\r\n`);
+      } else if (msg.type === 'editor-open') {
+        if (this.props.onEditorOpen) {
+          this.props.onEditorOpen(msg.sessionId, msg.filePath);
+        }
+      }
+    });
+
+    // Subscribe to terminal data stream (triggers buffer replay from server)
+    ctx.subscribeTerminal(tid);
+
+    // Send initial resize
+    this.sendResize();
+  }
+
+  /**
+   * Send a message through the appropriate WebSocket channel.
+   * In context-mediated mode, uses TerminalContext.sendMessage.
+   * In legacy mode, uses the local WebSocket.
+   */
+  _sendWsMessage(msg) {
+    if (this._useContextWs) {
+      const ctx = this.context;
+      if (ctx) ctx.sendMessage(msg);
+    } else if (this.ws && this.ws.readyState === WebSocket.OPEN) {
       this.ws.send(JSON.stringify(msg));
     }
+  }
+
+  /**
+   * Check if the WebSocket channel (either shared or local) is ready.
+   */
+  _isWsReady() {
+    if (this._useContextWs) {
+      const ctx = this.context;
+      return ctx && ctx.getWs() !== null;
+    }
+    return this.ws && this.ws.readyState === WebSocket.OPEN;
+  }
+
+  sendResize() {
+    if (!this.terminal) return;
+    const msg = {
+      type: 'resize',
+      cols: this.terminal.cols,
+      rows: this.terminal.rows,
+    };
+    if (this.props.tid) msg.tid = this.props.tid;
+    if (isMobile) msg.mobile = true;
+    this._sendWsMessage(msg);
   }
 
   setupResizeObserver() {
@@ -714,13 +816,15 @@ class TerminalPanel extends React.Component {
     // 当 shell 已启用 bracketedPasteMode 时，xterm.js 会自动包裹，无需干预
     if (this.terminal?.modes?.bracketedPasteMode) return;
     const text = e.clipboardData?.getData('text');
-    if (!text || !this.ws || this.ws.readyState !== WebSocket.OPEN) return;
-    // shell 未启用 bracketed paste 时，手动包裹多行文本，防止换行被当作 Enter 执行
+    if (!text || !this._isWsReady()) return;
+    // shell 未启用 bracketed paste 时，手動包裹多行文本，防止换行被当作 Enter 执行
     if (text.includes('\n') || text.includes('\r')) {
       e.preventDefault();
       e.stopPropagation();
       const wrapped = `\x1b[200~${text}\x1b[201~`;
-      this.ws.send(JSON.stringify({ type: 'input', data: wrapped }));
+      const msg = { type: 'input', data: wrapped };
+      if (this.props.tid) msg.tid = this.props.tid;
+      this._sendWsMessage(msg);
     }
   };
 
@@ -730,8 +834,8 @@ class TerminalPanel extends React.Component {
       const path = await uploadFileAndGetPath(optimized);
       if (this.props.onFilePath) this.props.onFilePath(path);
       // Notify other views/devices about the uploaded image
-      if (this.ws && this.ws.readyState === WebSocket.OPEN) {
-        this.ws.send(JSON.stringify({ type: 'image-upload-notify', path, source: 'terminal' }));
+      if (this._isWsReady()) {
+        this._sendWsMessage({ type: 'image-upload-notify', path, source: 'terminal' });
       }
       if (this.terminal) this.terminal.focus();
     } catch (err) {
@@ -772,8 +876,10 @@ class TerminalPanel extends React.Component {
   }
 
   handleVirtualKey = (seq) => {
-    if (this.ws && this.ws.readyState === WebSocket.OPEN) {
-      this.ws.send(JSON.stringify({ type: 'input', data: seq }));
+    if (this._isWsReady()) {
+      const msg = { type: 'input', data: seq };
+      if (this.props.tid) msg.tid = this.props.tid;
+      this._sendWsMessage(msg);
     }
     // 手机上不 focus 终端，避免弹出系统软键盘；主动 blur 防止先前已聚焦
     if (isMobile && !isPad) {
@@ -824,8 +930,8 @@ class TerminalPanel extends React.Component {
       const path = await uploadFileAndGetPath(file);
       if (this.props.onFilePath) this.props.onFilePath(path);
       // Notify other views/devices about the uploaded file
-      if (this.ws && this.ws.readyState === WebSocket.OPEN) {
-        this.ws.send(JSON.stringify({ type: 'image-upload-notify', path, source: 'terminal' }));
+      if (this._isWsReady()) {
+        this._sendWsMessage({ type: 'image-upload-notify', path, source: 'terminal' });
       }
       // refocus terminal after upload (skip on mobile to avoid system keyboard popup)
       if ((!isMobile || isPad) && this.terminal) this.terminal.focus();
@@ -953,23 +1059,27 @@ class TerminalPanel extends React.Component {
   handlePresetSend = (description) => {
     if (!description) return;
     this.setState({ agentTeamPopoverOpen: false });
-    if (this.ws && this.ws.readyState === WebSocket.OPEN) {
-      this.ws.send(JSON.stringify({
+    if (this._isWsReady()) {
+      const msg = {
         type: 'input-sequential',
         chunks: buildBracketPasteSubmitChunks(description),
         settleMs: BRACKET_PASTE_SUBMIT_SETTLE_MS,
-      }));
+      };
+      if (this.props.tid) msg.tid = this.props.tid;
+      this._sendWsMessage(msg);
     }
     if ((!isMobile || isPad) && this.terminal) this.terminal.focus();
   };
 
   handleClearContext = () => {
-    if (this.ws && this.ws.readyState === WebSocket.OPEN) {
-      this.ws.send(JSON.stringify({
+    if (this._isWsReady()) {
+      const msg = {
         type: 'input-sequential',
         chunks: buildBracketPasteSubmitChunks('/clear'),
         settleMs: BRACKET_PASTE_SUBMIT_SETTLE_MS,
-      }));
+      };
+      if (this.props.tid) msg.tid = this.props.tid;
+      this._sendWsMessage(msg);
       this.props.onClearContextOptimistic?.();
     }
     if ((!isMobile || isPad) && this.terminal) this.terminal.focus();
@@ -993,12 +1103,14 @@ class TerminalPanel extends React.Component {
     // 先校验再重置，避免空模板导致用户输入被静默清空
     if (!assembled) return;
     this.setState({ ultraplanOpen: false, ultraplanPrompt: '', ultraplanVariant: 'codeExpert', ultraplanFiles: [] });
-    if (this.ws && this.ws.readyState === WebSocket.OPEN) {
-      this.ws.send(JSON.stringify({
+    if (this._isWsReady()) {
+      const msg = {
         type: 'input-sequential',
         chunks: buildBracketPasteSubmitChunks(assembled),
         settleMs: BRACKET_PASTE_SUBMIT_SETTLE_MS,
-      }));
+      };
+      if (this.props.tid) msg.tid = this.props.tid;
+      this._sendWsMessage(msg);
     }
     if ((!isMobile || isPad) && this.terminal) this.terminal.focus();
   };
@@ -1104,11 +1216,13 @@ class TerminalPanel extends React.Component {
   handleEnableAgentTeam = () => {
     if (this.state.agentTeamEnabling) return;
     this.setState({ agentTeamEnabling: true });
-    if (this.ws && this.ws.readyState === WebSocket.OPEN) {
+    if (this._isWsReady()) {
       // 用当前真实的配置目录拼 prompt，避免 CLAUDE_CONFIG_DIR 用户让 Claude 去改错文件
       const settingsPath = `${getClaudeConfigDir()}/settings.json`;
       const prompt = `Add "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1" to the env object in ${settingsPath}. If the env key does not exist, create it. Preserve all existing content. Only modify this one field. If ${settingsPath} does not exist, instead add the line: export CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1 to the user's shell profile (~/.zshrc or ~/.bashrc).`;
-      this.ws.send(JSON.stringify({ type: 'input', data: prompt + '\r' }));
+      const msg = { type: 'input', data: prompt + '\r' };
+      if (this.props.tid) msg.tid = this.props.tid;
+      this._sendWsMessage(msg);
       message.success('需要重启 Claude Code 才能生效');
     }
     if ((!isMobile || isPad) && this.terminal) this.terminal.focus();

--- a/src/components/TerminalTabBar.jsx
+++ b/src/components/TerminalTabBar.jsx
@@ -1,0 +1,242 @@
+import React, { useState, useRef, useCallback, useEffect } from 'react';
+import { useTerminalContext } from './TerminalContext';
+import { isMobile } from '../env';
+import styles from './TerminalTabBar.module.css';
+
+/**
+ * Bottom tab bar for switching between multiple terminals.
+ * Mobile: 44px touch targets, horizontal scroll, long-press to close.
+ * PC: X close button on each tab, double-click to rename.
+ */
+export default function TerminalTabBar({ onOpenDashboard }) {
+  const { terminals, activeTid, switchTerminal, createTerminal, closeTerminal, renameTerminal, sendMessage } = useTerminalContext();
+  const [longPressTarget, setLongPressTarget] = useState(null);
+  const longPressTimerRef = useRef(null);
+  const scrollRef = useRef(null);
+
+  // Rename state
+  const [editingTid, setEditingTid] = useState(null);
+  const [editValue, setEditValue] = useState('');
+  const editInputRef = useRef(null);
+
+  // Focus input when entering edit mode
+  useEffect(() => {
+    if (editingTid && editInputRef.current) {
+      editInputRef.current.focus();
+      editInputRef.current.select();
+    }
+  }, [editingTid]);
+
+  const handleTouchStart = useCallback((tid, e) => {
+    // Long press detection for close (mobile only)
+    longPressTimerRef.current = setTimeout(() => {
+      setLongPressTarget(tid);
+    }, 600);
+  }, []);
+
+  const handleTouchEnd = useCallback((tid) => {
+    if (longPressTimerRef.current) {
+      clearTimeout(longPressTimerRef.current);
+      longPressTimerRef.current = null;
+    }
+  }, []);
+
+  const handleTouchMove = useCallback(() => {
+    if (longPressTimerRef.current) {
+      clearTimeout(longPressTimerRef.current);
+      longPressTimerRef.current = null;
+    }
+  }, []);
+
+  const handleTabClick = useCallback((tid) => {
+    if (longPressTarget) return; // ignore click after long press
+    switchTerminal(tid);
+  }, [switchTerminal, longPressTarget]);
+
+  // Double-click to enter rename mode
+  const handleDoubleClick = useCallback((tid, currentTitle) => {
+    setEditingTid(tid);
+    setEditValue(currentTitle || '');
+  }, []);
+
+  // Confirm rename
+  const commitRename = useCallback(() => {
+    if (editingTid && editValue.trim()) {
+      renameTerminal(editingTid, editValue.trim());
+    }
+    setEditingTid(null);
+    setEditValue('');
+  }, [editingTid, editValue, renameTerminal]);
+
+  // Handle rename input key events
+  const handleRenameKeyDown = useCallback((e) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      commitRename();
+    } else if (e.key === 'Escape') {
+      setEditingTid(null);
+      setEditValue('');
+    }
+  }, [commitRename]);
+
+  // PC close confirmation state
+  const [pcCloseTarget, setPcCloseTarget] = useState(null);
+
+  const handleClose = useCallback((tid) => {
+    closeTerminal(tid);
+    setLongPressTarget(null);
+    setPcCloseTarget(null);
+  }, [closeTerminal]);
+
+  const handlePcCloseRequest = useCallback((tid) => {
+    setPcCloseTarget(tid);
+  }, []);
+
+  const dismissPcClose = useCallback(() => {
+    setPcCloseTarget(null);
+  }, []);
+
+  const handleCreate = useCallback(() => {
+    createTerminal();
+  }, [createTerminal]);
+
+  // Detach a tmux-attached terminal by sending Ctrl+B then 'd' (with 100ms delay)
+  const handleDetach = useCallback((tid) => {
+    sendMessage({ type: 'input', data: '\x02', tid });
+    setTimeout(() => {
+      sendMessage({ type: 'input', data: 'd', tid });
+    }, 100);
+  }, [sendMessage]);
+
+  const dismissLongPress = useCallback(() => {
+    setLongPressTarget(null);
+  }, []);
+
+  const terminalList = Array.from(terminals.values());
+
+  return (
+    <div className={styles.tabBarContainer}>
+      {/* Dashboard pull handle */}
+      {onOpenDashboard && (
+        <button
+          className={styles.dashboardHandle}
+          onClick={onOpenDashboard}
+          aria-label="Open dashboard"
+          title="Dashboard"
+        >
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <rect x="3" y="3" width="7" height="7" />
+            <rect x="14" y="3" width="7" height="7" />
+            <rect x="3" y="14" width="7" height="7" />
+            <rect x="14" y="14" width="7" height="7" />
+          </svg>
+        </button>
+      )}
+
+      {/* Scrollable tab area */}
+      <div className={styles.tabScroll} ref={scrollRef}>
+        {terminalList.map((term, idx) => {
+          const isActive = term.tid === activeTid;
+          const isExited = term.status === 'exited';
+          const isEditing = editingTid === term.tid;
+          const isTmux = term.tid.startsWith('tmux-') || (term.title && term.title.startsWith('tmux:'));
+          const displayLabel = isTmux
+            ? `\u2388 ${term.title || `T${idx + 1}`}`
+            : (term.title || `T${idx + 1}`);
+          return (
+            <button
+              key={term.tid}
+              className={`${styles.tab} ${isActive ? styles.tabActive : ''} ${isTmux ? styles.tabTmux : ''}`}
+              onClick={() => handleTabClick(term.tid)}
+              onDoubleClick={() => handleDoubleClick(term.tid, term.title || `T${idx + 1}`)}
+              onTouchStart={isMobile ? (e) => handleTouchStart(term.tid, e) : undefined}
+              onTouchEnd={isMobile ? () => handleTouchEnd(term.tid) : undefined}
+              onTouchMove={isMobile ? handleTouchMove : undefined}
+            >
+              <span className={`${styles.statusDot} ${isExited ? styles.statusExited : styles.statusRunning}`} />
+              {isEditing ? (
+                <input
+                  ref={editInputRef}
+                  className={styles.tabRenameInput}
+                  value={editValue}
+                  onChange={(e) => setEditValue(e.target.value)}
+                  onKeyDown={handleRenameKeyDown}
+                  onBlur={commitRename}
+                  onClick={(e) => e.stopPropagation()}
+                  onDoubleClick={(e) => e.stopPropagation()}
+                  maxLength={32}
+                />
+              ) : (
+                <span className={styles.tabLabel}>
+                  {displayLabel}
+                </span>
+              )}
+              {/* Detach button for tmux tabs */}
+              {!isEditing && isTmux && (
+                <span
+                  className={styles.detachBtn}
+                  onClick={(e) => { e.stopPropagation(); handleDetach(term.tid); }}
+                  title="Detach tmux session"
+                >
+                  &#x23CF;
+                </span>
+              )}
+              {/* PC: always show close button; Mobile: show only on long press */}
+              {!isMobile && !isEditing && (
+                <span
+                  className={styles.pcCloseBtn}
+                  onClick={(e) => { e.stopPropagation(); handlePcCloseRequest(term.tid); }}
+                  title="Close terminal"
+                >
+                  <svg width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round">
+                    <line x1="2" y1="2" x2="8" y2="8" />
+                    <line x1="8" y1="2" x2="2" y2="8" />
+                  </svg>
+                </span>
+              )}
+              {isMobile && longPressTarget === term.tid && (
+                <span className={styles.closeBtn} onClick={(e) => { e.stopPropagation(); handleClose(term.tid); }}>
+                  x
+                </span>
+              )}
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Close confirmation overlay (mobile long press) */}
+      {isMobile && longPressTarget && (
+        <div className={styles.longPressOverlay} onClick={dismissLongPress}>
+          <div className={styles.longPressCard} onClick={(e) => e.stopPropagation()}>
+            <p className={styles.longPressText}>Close this terminal?</p>
+            <div className={styles.longPressActions}>
+              <button className={styles.longPressCancel} onClick={dismissLongPress}>Cancel</button>
+              <button className={styles.longPressConfirm} onClick={() => handleClose(longPressTarget)}>Close</button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Close confirmation overlay (PC X button) */}
+      {!isMobile && pcCloseTarget && (
+        <div className={styles.longPressOverlay} onClick={dismissPcClose}>
+          <div className={styles.longPressCard} onClick={(e) => e.stopPropagation()}>
+            <p className={styles.longPressText}>Close this terminal? Process will be terminated.</p>
+            <div className={styles.longPressActions}>
+              <button className={styles.longPressCancel} onClick={dismissPcClose}>Cancel</button>
+              <button className={styles.longPressConfirm} onClick={() => handleClose(pcCloseTarget)}>Close</button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Add terminal button */}
+      <button className={styles.addBtn} onClick={handleCreate} aria-label="New terminal">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round">
+          <line x1="12" y1="5" x2="12" y2="19" />
+          <line x1="5" y1="12" x2="19" y2="12" />
+        </svg>
+      </button>
+    </div>
+  );
+}

--- a/src/components/TerminalTabBar.module.css
+++ b/src/components/TerminalTabBar.module.css
@@ -1,0 +1,269 @@
+.tabBarContainer {
+  display: flex;
+  align-items: center;
+  height: 44px;
+  flex-shrink: 0;
+  background: #1a1a1a;
+  border-top: 1px solid var(--border-primary);
+  padding: 0 4px;
+  gap: 2px;
+  /* Prevent iOS overscroll from bleeding through the tab bar */
+  overscroll-behavior: none;
+}
+
+.dashboardHandle {
+  flex-shrink: 0;
+  width: 36px;
+  height: 36px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(59, 130, 246, 0.1);
+  border: 1px solid rgba(59, 130, 246, 0.3);
+  border-radius: 6px;
+  color: #60a5fa;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+  transition: background 0.15s, border-color 0.15s, color 0.15s;
+}
+
+.dashboardHandle:hover {
+  background: rgba(59, 130, 246, 0.18);
+  border-color: rgba(59, 130, 246, 0.5);
+  color: #93bbfd;
+}
+
+.dashboardHandle:active {
+  background: rgba(59, 130, 246, 0.25);
+  color: var(--text-primary);
+}
+
+.tabScroll {
+  flex: 1;
+  display: flex;
+  overflow-x: auto;
+  gap: 4px;
+  padding: 0 4px;
+  -webkit-overflow-scrolling: touch;
+  scrollbar-width: none;
+}
+
+.tabScroll::-webkit-scrollbar {
+  display: none;
+}
+
+.tab {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  height: 34px;
+  padding: 0 12px;
+  min-width: 60px;
+  max-width: 140px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-secondary);
+  border-radius: 6px;
+  color: var(--text-secondary);
+  font-size: 12px;
+  cursor: pointer;
+  user-select: none;
+  -webkit-tap-highlight-color: transparent;
+  transition: background 0.15s, border-color 0.15s;
+}
+
+.tab:active {
+  background: var(--bg-surface);
+}
+
+.tabActive {
+  background: var(--bg-surface);
+  border-color: var(--color-primary);
+  color: var(--text-primary);
+}
+
+.tabTmux {
+  border-color: rgba(74, 222, 128, 0.35);
+}
+
+.tabTmux.tabActive {
+  border-color: #4ade80;
+}
+
+.statusDot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.statusRunning {
+  background: #4ade80;
+  box-shadow: 0 0 4px rgba(74, 222, 128, 0.4);
+}
+
+.statusExited {
+  background: #666;
+}
+
+.tabLabel {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+
+.closeBtn {
+  flex-shrink: 0;
+  width: 18px;
+  height: 18px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.1);
+  color: var(--text-muted);
+  font-size: 11px;
+  margin-left: auto;
+}
+
+/* Detach button for tmux tabs -- visible on hover */
+.detachBtn {
+  flex-shrink: 0;
+  width: 16px;
+  height: 16px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 4px;
+  color: #f59e0b;
+  font-size: 11px;
+  line-height: 1;
+  margin-left: auto;
+  opacity: 0;
+  cursor: pointer;
+  transition: opacity 0.15s, background 0.15s, color 0.15s;
+}
+
+.tab:hover .detachBtn {
+  opacity: 1;
+}
+
+.detachBtn:hover {
+  background: rgba(245, 158, 11, 0.2);
+  color: #fbbf24;
+}
+
+/* PC close button -- visible on hover */
+.pcCloseBtn {
+  flex-shrink: 0;
+  width: 16px;
+  height: 16px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 4px;
+  color: var(--text-muted);
+  margin-left: auto;
+  opacity: 0;
+  transition: opacity 0.15s, background 0.15s, color 0.15s;
+}
+
+.tab:hover .pcCloseBtn {
+  opacity: 1;
+}
+
+.pcCloseBtn:hover {
+  background: rgba(255, 255, 255, 0.15);
+  color: #ef4444;
+}
+
+/* Inline rename input */
+.tabRenameInput {
+  width: 80px;
+  height: 20px;
+  padding: 0 4px;
+  border: 1px solid var(--color-primary);
+  border-radius: 3px;
+  background: var(--bg-surface);
+  color: var(--text-primary);
+  font-size: 12px;
+  font-family: inherit;
+  outline: none;
+  min-width: 40px;
+}
+
+.addBtn {
+  flex-shrink: 0;
+  width: 36px;
+  height: 36px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: 1px dashed var(--border-secondary);
+  border-radius: 6px;
+  color: var(--text-muted);
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+  transition: border-color 0.15s, color 0.15s;
+}
+
+.addBtn:active {
+  border-color: var(--color-primary);
+  color: var(--color-primary);
+}
+
+/* Long press close confirmation */
+.longPressOverlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.longPressCard {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-hover);
+  border-radius: 12px;
+  padding: 20px 24px;
+  min-width: 240px;
+  text-align: center;
+}
+
+.longPressText {
+  color: var(--text-primary);
+  font-size: 14px;
+  margin: 0 0 16px 0;
+}
+
+.longPressActions {
+  display: flex;
+  gap: 12px;
+  justify-content: center;
+}
+
+.longPressCancel {
+  padding: 8px 20px;
+  border: 1px solid var(--border-secondary);
+  border-radius: 6px;
+  background: var(--bg-surface);
+  color: var(--text-secondary);
+  font-size: 13px;
+  cursor: pointer;
+  min-height: 36px;
+}
+
+.longPressConfirm {
+  padding: 8px 20px;
+  border: none;
+  border-radius: 6px;
+  background: #ef4444;
+  color: #fff;
+  font-size: 13px;
+  cursor: pointer;
+  min-height: 36px;
+}

--- a/terminal-manager.js
+++ b/terminal-manager.js
@@ -1,0 +1,671 @@
+/**
+ * terminal-manager.js — Multi-terminal manager for CC Viewer
+ *
+ * Wraps pty-manager's core logic to support multiple concurrent terminal instances.
+ * Each terminal is identified by a string `tid` (terminal id).
+ * Backward compatible: a 'default' terminal is created on first use.
+ */
+
+import { resolveNativePath } from './findcc.js';
+import { fileURLToPath } from 'node:url';
+import { join, dirname } from 'node:path';
+import { chmodSync, statSync } from 'node:fs';
+import { platform, arch } from 'node:os';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+// ─── Constants ───────────────────────────────────────────────────
+export const MAX_TERMINALS = 8;
+const MAX_BUFFER = 200000;
+
+// ─── Shared Helpers ──────────────────────────────────────────────
+
+let _ptyImportForTests = null;
+
+export function _setPtyImportForTests(fn) {
+  _ptyImportForTests = fn;
+}
+
+async function getPty() {
+  if (typeof _ptyImportForTests === 'function') {
+    return _ptyImportForTests();
+  }
+  const ptyMod = await import('node-pty');
+  return ptyMod.default || ptyMod;
+}
+
+/**
+ * Find a safe slice start in a buffer to avoid cutting ANSI escape sequences.
+ * Scans forward from rawStart up to 64 bytes looking for a safe position.
+ */
+function findSafeSliceStart(buf, rawStart) {
+  const scanLimit = Math.min(rawStart + 64, buf.length);
+  let i = rawStart;
+  while (i < scanLimit) {
+    const ch = buf.charCodeAt(i);
+    if (ch === 0x1b) {
+      let j = i + 1;
+      while (j < scanLimit && !((buf.charCodeAt(j) >= 0x40 && buf.charCodeAt(j) <= 0x7e) && j > i + 1)) {
+        j++;
+      }
+      if (j < scanLimit) {
+        return j + 1;
+      }
+      i = j;
+      continue;
+    }
+    if ((ch >= 0x20 && ch <= 0x3f)) {
+      i++;
+      continue;
+    }
+    break;
+  }
+  return i < buf.length ? i : rawStart;
+}
+
+function fixSpawnHelperPermissions() {
+  try {
+    const os = platform();
+    const cpu = arch();
+    const helperPath = join(__dirname, 'node_modules', 'node-pty', 'prebuilds', `${os}-${cpu}`, 'spawn-helper');
+    const stat = statSync(helperPath);
+    if (!(stat.mode & 0o111)) {
+      chmodSync(helperPath, stat.mode | 0o755);
+    }
+  } catch { }
+}
+
+// ─── Terminal Instance ───────────────────────────────────────────
+
+/**
+ * @typedef {Object} TerminalInstance
+ * @property {string} tid
+ * @property {object|null} ptyProcess
+ * @property {Function[]} dataListeners
+ * @property {Function[]} exitListeners
+ * @property {number|null} lastExitCode
+ * @property {string} outputBuffer
+ * @property {string|null} currentWorkspacePath
+ * @property {string|null} lastWorkspacePath
+ * @property {number} cols
+ * @property {number} rows
+ * @property {string} batchBuffer
+ * @property {boolean} batchScheduled
+ * @property {number} createdAt
+ * @property {string} label
+ */
+
+/** @type {Map<string, TerminalInstance>} */
+const terminals = new Map();
+
+/**
+ * Create a new terminal instance slot (does not spawn a process).
+ * @param {string} tid - Terminal identifier
+ * @param {object} [options]
+ * @param {string} [options.label] - Human-readable label
+ * @param {string} [options.cwd] - Initial working directory
+ * @param {number} [options.cols=120]
+ * @param {number} [options.rows=30]
+ * @returns {TerminalInstance}
+ */
+export function createTerminal(tid, options = {}) {
+  if (terminals.has(tid)) {
+    return terminals.get(tid);
+  }
+  if (terminals.size >= MAX_TERMINALS) {
+    throw new Error(`Maximum terminal limit (${MAX_TERMINALS}) reached`);
+  }
+
+  const instance = {
+    tid,
+    ptyProcess: null,
+    dataListeners: [],
+    exitListeners: [],
+    lastExitCode: null,
+    outputBuffer: '',
+    currentWorkspacePath: options.cwd || null,
+    lastWorkspacePath: options.cwd || null,
+    cols: options.cols || 120,
+    rows: options.rows || 30,
+    batchBuffer: '',
+    batchScheduled: false,
+    createdAt: Date.now(),
+    label: options.label || tid,
+  };
+
+  terminals.set(tid, instance);
+  return instance;
+}
+
+// ─── Batch Flush (per-instance) ──────────────────────────────────
+
+function flushBatch(inst) {
+  inst.batchScheduled = false;
+  if (!inst.batchBuffer) return;
+  const chunk = inst.batchBuffer;
+  inst.batchBuffer = '';
+  for (const cb of inst.dataListeners) {
+    try { cb(chunk); } catch { }
+  }
+}
+
+// ─── Attach PTY listeners (shared between spawnClaude and spawnShell) ─
+
+function attachPtyListeners(inst) {
+  const proc = inst.ptyProcess;
+  if (!proc) return;
+
+  proc.onData((data) => {
+    inst.outputBuffer += data;
+    if (inst.outputBuffer.length > MAX_BUFFER) {
+      const rawStart = inst.outputBuffer.length - MAX_BUFFER;
+      const safeStart = findSafeSliceStart(inst.outputBuffer, rawStart);
+      inst.outputBuffer = inst.outputBuffer.slice(safeStart);
+    }
+    inst.batchBuffer += data;
+    if (!inst.batchScheduled) {
+      inst.batchScheduled = true;
+      setImmediate(() => flushBatch(inst));
+    }
+  });
+
+  proc.onExit(({ exitCode }) => {
+    flushBatch(inst);
+    inst.lastExitCode = exitCode;
+    inst.ptyProcess = null;
+    inst.currentWorkspacePath = null;
+    for (const cb of inst.exitListeners) {
+      try { cb(exitCode); } catch { }
+    }
+  });
+}
+
+// ─── Spawn Claude ────────────────────────────────────────────────
+
+/**
+ * Spawn a Claude process in the given terminal.
+ * If the terminal does not exist yet, it is created automatically.
+ *
+ * @param {string} tid
+ * @param {number} proxyPort
+ * @param {string} cwd
+ * @param {string[]} [extraArgs=[]]
+ * @param {string|null} [claudePath=null]
+ * @param {boolean} [isNpmVersion=false]
+ * @param {number|null} [serverPort=null]
+ * @returns {Promise<object>} The spawned pty process
+ */
+export async function spawnClaude(tid, proxyPort, cwd, extraArgs = [], claudePath = null, isNpmVersion = false, serverPort = null) {
+  let inst = terminals.get(tid);
+  if (!inst) {
+    inst = createTerminal(tid);
+  }
+
+  // Kill existing process in this terminal
+  if (inst.ptyProcess) {
+    killTerminal(tid);
+  }
+
+  const pty = await getPty();
+  fixSpawnHelperPermissions();
+
+  if (!claudePath) {
+    claudePath = resolveNativePath();
+    if (!claudePath) {
+      throw new Error('claude not found');
+    }
+  }
+
+  const env = { ...process.env };
+  env.ANTHROPIC_BASE_URL = `http://127.0.0.1:${proxyPort}`;
+  env.CCV_PROXY_MODE = '1';
+
+  let nodePath = process.execPath;
+  if (process.versions.electron) {
+    const { execSync } = await import('node:child_process');
+    try {
+      nodePath = execSync(process.platform === 'win32' ? 'where node' : 'which node', { encoding: 'utf-8' }).trim();
+      if (process.platform === 'win32') nodePath = nodePath.split('\n')[0].trim();
+    } catch {
+      nodePath = process.platform === 'win32' ? 'node' : '/usr/local/bin/node';
+    }
+  }
+
+  if (serverPort) {
+    const editorScript = join(__dirname, 'lib', 'ccv-editor.js');
+    env.EDITOR = `${nodePath} ${editorScript}`;
+    env.VISUAL = env.EDITOR;
+    env.CCV_EDITOR_PORT = String(serverPort);
+    env.CCVIEWER_PORT = String(serverPort);
+  }
+
+  const settingsJson = JSON.stringify({
+    env: {
+      ANTHROPIC_BASE_URL: env.ANTHROPIC_BASE_URL
+    }
+  });
+
+  let command = claudePath;
+  let args = ['--settings', settingsJson, ...extraArgs];
+
+  if (isNpmVersion && claudePath.endsWith('.js')) {
+    command = nodePath;
+    args = [claudePath, '--settings', settingsJson, ...extraArgs];
+  }
+
+  inst.lastExitCode = null;
+  inst.outputBuffer = '';
+  inst.currentWorkspacePath = cwd || process.cwd();
+  inst.lastWorkspacePath = inst.currentWorkspacePath;
+
+  inst.ptyProcess = pty.spawn(command, args, {
+    name: 'xterm-256color',
+    cols: inst.cols,
+    rows: inst.rows,
+    cwd: inst.currentWorkspacePath,
+    env,
+  });
+
+  // Handle auto-retry on "No conversation found" (same as pty-manager)
+  const retryHandler = (exitCode) => {
+    const hasContinue = extraArgs.includes('-c') || extraArgs.includes('--continue');
+    if (hasContinue && exitCode !== 0 && inst.outputBuffer.includes('No conversation found')) {
+      console.error(`[CC Viewer] Terminal ${tid}: -c failed (no conversation), retrying without -c`);
+      const retryArgs = extraArgs.filter(a => a !== '-c' && a !== '--continue');
+      // Remove the retry handler before re-spawning
+      inst.exitListeners = inst.exitListeners.filter(cb => cb !== retryHandler);
+      spawnClaude(tid, proxyPort, cwd, retryArgs, claudePath, isNpmVersion, serverPort);
+    }
+  };
+  inst.exitListeners.unshift(retryHandler);
+
+  attachPtyListeners(inst);
+
+  return inst.ptyProcess;
+}
+
+// ─── Spawn Shell ─────────────────────────────────────────────────
+
+/**
+ * Spawn an interactive shell in the given terminal after process exit.
+ * @param {string} tid
+ * @returns {Promise<boolean>}
+ */
+export async function spawnShell(tid) {
+  const inst = terminals.get(tid);
+  if (!inst) return false;
+  if (inst.ptyProcess) return false;
+
+  const cwd = inst.lastWorkspacePath || process.cwd();
+  const pty = await getPty();
+  fixSpawnHelperPermissions();
+
+  const shell = process.env.SHELL || '/bin/sh';
+
+  inst.lastExitCode = null;
+  inst.currentWorkspacePath = cwd;
+
+  const shellEnv = { ...process.env };
+  delete shellEnv.CCVIEWER_PORT;
+  delete shellEnv.CCV_EDITOR_PORT;
+
+  inst.ptyProcess = pty.spawn(shell, [], {
+    name: 'xterm-256color',
+    cols: inst.cols,
+    rows: inst.rows,
+    cwd,
+    env: shellEnv,
+  });
+
+  attachPtyListeners(inst);
+  return true;
+}
+
+// ─── Attach to existing tmux session ─────────────────────────────
+
+/**
+ * Attach to an existing tmux session in the given terminal.
+ * @param {string} tid - terminal id
+ * @param {string} tmuxTarget - tmux target (session name or session:window.pane)
+ * @param {boolean} [readOnly=false] - if true, attach with -r flag
+ * @returns {Promise<boolean>}
+ */
+export async function attachTmux(tid, tmuxTarget, readOnly = false) {
+  const inst = terminals.get(tid);
+  if (!inst) return false;
+  if (inst.ptyProcess) return false; // already has a running process
+
+  const pty = await getPty();
+  fixSpawnHelperPermissions();
+
+  // Find tmux binary
+  const { execSync } = await import('node:child_process');
+  let tmuxPath;
+  try {
+    tmuxPath = execSync('which tmux', { encoding: 'utf-8' }).trim();
+  } catch {
+    return false; // tmux not available
+  }
+  if (!tmuxPath) return false;
+
+  const args = ['attach-session', '-t', tmuxTarget];
+  if (readOnly) args.push('-r');
+
+  inst.lastExitCode = null;
+  inst.currentWorkspacePath = null; // tmux manages its own cwd
+
+  const shellEnv = { ...process.env };
+  delete shellEnv.CCVIEWER_PORT;
+  delete shellEnv.CCV_EDITOR_PORT;
+
+  inst.ptyProcess = pty.spawn(tmuxPath, args, {
+    name: 'xterm-256color',
+    cols: inst.cols,
+    rows: inst.rows,
+    env: shellEnv,
+  });
+
+  attachPtyListeners(inst);
+  return true;
+}
+
+// ─── Create new tmux session ─────────────────────────────────────
+
+/**
+ * Create a new tmux session and attach to it in the given terminal.
+ * @param {string} tid - CCV terminal id
+ * @param {string} sessionName - desired tmux session name
+ * @param {string} cwd - working directory for the session
+ * @returns {Promise<boolean>}
+ */
+export async function createTmuxSession(tid, sessionName, cwd) {
+  const inst = terminals.get(tid);
+  if (!inst) return false;
+  if (inst.ptyProcess) return false;
+
+  const pty = await getPty();
+  fixSpawnHelperPermissions();
+
+  let tmuxPath;
+  try {
+    const { execSync } = await import('node:child_process');
+    tmuxPath = execSync('which tmux', { encoding: 'utf-8' }).trim();
+  } catch { return false; }
+
+  const args = ['new-session', '-s', sessionName];
+  if (cwd) args.push('-c', cwd);
+
+  inst.lastExitCode = null;
+  inst.currentWorkspacePath = cwd || null;
+
+  const shellEnv = { ...process.env };
+  delete shellEnv.CCVIEWER_PORT;
+  delete shellEnv.CCV_EDITOR_PORT;
+
+  inst.ptyProcess = pty.spawn(tmuxPath, args, {
+    name: 'xterm-256color',
+    cols: inst.cols,
+    rows: inst.rows,
+    cwd: cwd || undefined,
+    env: shellEnv,
+  });
+
+  attachPtyListeners(inst);
+  return true;
+}
+
+// ─── Terminal Operations ─────────────────────────────────────────
+
+/**
+ * Write data to a terminal's PTY process.
+ * @param {string} tid
+ * @param {string} data
+ * @returns {boolean}
+ */
+export function writeToTerminal(tid, data) {
+  const inst = terminals.get(tid);
+  if (inst && inst.ptyProcess) {
+    inst.ptyProcess.write(data);
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Send chunks sequentially to a terminal's PTY, with delays between each.
+ * @param {string} tid
+ * @param {string[]} chunks
+ * @param {Function} [onComplete]
+ * @param {object} [opts]
+ */
+export function writeToTerminalSequential(tid, chunks, onComplete, opts = {}) {
+  const inst = terminals.get(tid);
+  const timeoutMs = opts.timeoutMs || 4000;
+  const settleMs = opts.settleMs || 150;
+
+  if (!inst || !inst.ptyProcess || !chunks || chunks.length === 0) {
+    if (onComplete) onComplete(false);
+    return;
+  }
+
+  let idx = 0;
+
+  const sendNext = () => {
+    if (idx >= chunks.length || !inst.ptyProcess) {
+      if (onComplete) onComplete(true);
+      return;
+    }
+
+    const chunk = chunks[idx];
+    idx++;
+
+    inst.ptyProcess.write(chunk);
+
+    const isToggleOrSubmit = chunk === ' ' || chunk === '\r'
+      || chunk === '\x1b[C' || chunk === '\x1b[A' || chunk === '\x1b[B';
+    const delay = isToggleOrSubmit ? settleMs : 80;
+    setTimeout(sendNext, delay);
+  };
+
+  sendNext();
+}
+
+/**
+ * Resize a terminal's PTY.
+ * @param {string} tid
+ * @param {number} cols
+ * @param {number} rows
+ */
+export function resizeTerminal(tid, cols, rows) {
+  const inst = terminals.get(tid);
+  if (!inst) return;
+  inst.cols = cols;
+  inst.rows = rows;
+  if (inst.ptyProcess) {
+    try { inst.ptyProcess.resize(cols, rows); } catch { }
+  }
+}
+
+/**
+ * Kill the PTY process in a terminal (does not remove the terminal slot).
+ * @param {string} tid
+ */
+export function killTerminal(tid) {
+  const inst = terminals.get(tid);
+  if (!inst) return;
+  if (inst.ptyProcess) {
+    flushBatch(inst);
+    inst.batchBuffer = '';
+    inst.batchScheduled = false;
+    try { inst.ptyProcess.kill(); } catch { }
+    inst.ptyProcess = null;
+  }
+}
+
+/**
+ * Kill all terminal PTY processes across every registered terminal.
+ */
+export function killAllTerminals() {
+  for (const [tid] of terminals) {
+    killTerminal(tid);
+  }
+}
+
+/**
+ * Remove a terminal entirely (kill process + remove from registry).
+ * @param {string} tid
+ */
+export function removeTerminal(tid) {
+  killTerminal(tid);
+  terminals.delete(tid);
+}
+
+/**
+ * Rename a terminal's label.
+ * @param {string} tid
+ * @param {string} label - New human-readable label
+ * @returns {boolean} Whether the rename succeeded
+ */
+export function renameTerminal(tid, label) {
+  const inst = terminals.get(tid);
+  if (!inst) return false;
+  inst.label = label;
+  return true;
+}
+
+// ─── Query Methods ───────────────────────────────────────────────
+
+/**
+ * Get the state of a terminal.
+ * @param {string} tid
+ * @returns {{ running: boolean, exitCode: number|null, tid: string, label: string, createdAt: number }|null}
+ */
+export function getTerminalState(tid) {
+  const inst = terminals.get(tid);
+  if (!inst) return null;
+  return {
+    tid: inst.tid,
+    label: inst.label,
+    running: !!inst.ptyProcess,
+    exitCode: inst.lastExitCode,
+    createdAt: inst.createdAt,
+    cwd: inst.currentWorkspacePath || inst.lastWorkspacePath,
+  };
+}
+
+/**
+ * Get the full output buffer of a terminal.
+ * @param {string} tid
+ * @returns {string}
+ */
+export function getTerminalBuffer(tid) {
+  const inst = terminals.get(tid);
+  return inst ? inst.outputBuffer : '';
+}
+
+/**
+ * Check whether a line (after stripping ANSI escapes) is decorative / status-bar noise.
+ * Decorative lines include box-drawing borders, empty prompts, and progress bars.
+ */
+function isDecorativeLine(raw) {
+  // Strip ANSI escape sequences
+  const line = raw.replace(/\x1b\[[0-9;]*[A-Za-z]/g, '').replace(/\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)/g, '').replace(/\x1b[()][AB012]/g, '').trim();
+  if (!line) return true;
+  // Line consists entirely of box-drawing / decoration characters and whitespace
+  if (/^[\s\u2500-\u257f\u2580-\u259f\u2550-\u256c\u2190-\u21ff─═│┌┐└┘├┤┬┴┼↯░▓█▒\-=|+]+$/.test(line)) return true;
+  // Line is just a prompt symbol with optional whitespace
+  if (/^[❯$%>#\s]+$/.test(line)) return true;
+  // Progress bars or status bars with block chars or percentage
+  if (/[░▓█▒]/.test(line)) return true;
+  if (/\d+(\.\d+)?%/.test(line) && line.length < 80) return true;
+  // CC status bar: emoji + model stats
+  if (/[🏢🌐🔧⚙️🤖💬📎✓✗⚡]/.test(line) && line.length < 80) return true;
+  // Short lines (< 25 chars) that are likely UI labels, not content
+  if (line.length < 25) return true;
+  return false;
+}
+
+/**
+ * Get the last N meaningful lines from a terminal's output buffer,
+ * skipping decorative borders, empty prompts, and status bars.
+ * @param {string} tid
+ * @param {number} [lines=5]
+ * @returns {string}
+ */
+export function getTerminalBufferPreview(tid, lines = 5) {
+  const inst = terminals.get(tid);
+  if (!inst || !inst.outputBuffer) return '';
+  const allLines = inst.outputBuffer.split('\n');
+
+  // Scan backwards to collect the requested number of meaningful lines
+  const meaningful = [];
+  for (let i = allLines.length - 1; i >= 0 && meaningful.length < lines; i--) {
+    if (!isDecorativeLine(allLines[i])) {
+      meaningful.unshift(allLines[i]);
+    }
+  }
+
+  return meaningful.join('\n');
+}
+
+/**
+ * Get the PID of a terminal's PTY process.
+ * @param {string} tid
+ * @returns {number|null}
+ */
+export function getTerminalPid(tid) {
+  const inst = terminals.get(tid);
+  return inst && inst.ptyProcess ? inst.ptyProcess.pid : null;
+}
+
+/**
+ * List all terminals with their basic state.
+ * @returns {Array<{ tid: string, label: string, running: boolean, exitCode: number|null, createdAt: number, cwd: string|null }>}
+ */
+export function listTerminals() {
+  const result = [];
+  for (const [tid, inst] of terminals) {
+    result.push({
+      tid,
+      label: inst.label,
+      running: !!inst.ptyProcess,
+      exitCode: inst.lastExitCode,
+      createdAt: inst.createdAt,
+      cwd: inst.currentWorkspacePath || inst.lastWorkspacePath,
+    });
+  }
+  return result;
+}
+
+// ─── Event Subscriptions ─────────────────────────────────────────
+
+/**
+ * Register a data listener for a terminal.
+ * @param {string} tid
+ * @param {Function} callback
+ * @returns {Function} Unsubscribe function
+ */
+export function onTerminalData(tid, callback) {
+  const inst = terminals.get(tid);
+  if (!inst) return () => {};
+  inst.dataListeners.push(callback);
+  return () => {
+    inst.dataListeners = inst.dataListeners.filter(l => l !== callback);
+  };
+}
+
+/**
+ * Register an exit listener for a terminal.
+ * @param {string} tid
+ * @param {Function} callback
+ * @returns {Function} Unsubscribe function
+ */
+export function onTerminalExit(tid, callback) {
+  const inst = terminals.get(tid);
+  if (!inst) return () => {};
+  inst.exitListeners.push(callback);
+  return () => {
+    inst.exitListeners = inst.exitListeners.filter(l => l !== callback);
+  };
+}


### PR DESCRIPTION
  描述:                                                                                                                                 
  ## 概述
  为 cc-viewer 添加完整的多终端基础设施，支持同时运行多个终端实例并通过 Tab 栏切换管理。                                                
                                                                        
  ## 新增功能                            
  - 多终端 Tab 栏：创建、切换、关闭终端实例（最多 8 个）
  - 终端改名：双击 Tab 名称即可编辑
  - 关闭确认：PC 点击 X / 手机长按，弹窗二次确认防误关
  - tmux 仪表盘：发现本地 tmux session，支持挂载/创建/分离
  - 安全增强：非本地 WebSocket 连接使用 timing-safe token 认证

  ## 改动范围
  - 8 个新文件（+3,320 行）：terminal-manager、TerminalContext、MultiTerminalView、TerminalTabBar、DashboardOverlay
  - 5 个修改文件（-166 行）：server.js（多终端 WS 协议 + REST API）、cli.js、TerminalPanel、ChatView、Mobile

  ## 测试情况
  - [x] 编译通过（node build.js）
  - [x] PC 端本地验证
  - [x] 手机端本地验证
  - [x] 多终端创建/关闭/改名功能正常
  - [x] Tab 切换保留终端缓冲区内容
  - [x] 关闭确认弹窗 PC/手机均正常