### PR TITLE
feat(plugin): add onStreamChunk hook for plugin-level SSE streaming support

### DIFF
--- a/lib/plugin-loader.js
+++ b/lib/plugin-loader.js
@@ -19,6 +19,7 @@ const HOOK_TYPES = {
   serverStarted: 'parallel',
   serverStopping: 'parallel',
   onNewEntry: 'parallel',
+  onStreamChunk: 'parallel',
 };
 
 let _plugins = [];

--- a/server.js
+++ b/server.js
@@ -2170,12 +2170,14 @@ async function handleRequest(req, res) {
         }
         // 用 named event 'stream-progress' 避免混入 data: 流与 dedup 冲突
         // 精简 payload：前端只需要 timestamp/url/content 渲染 Live overlay
-        sendEventToClients(clients, 'stream-progress', {
+        const _streamChunkPayload = {
           timestamp: entry.timestamp,
           url: entry.url,
           content: entry.response?.body?.content || [],
           model: entry.body?.model,
-        });
+        };
+        sendEventToClients(clients, 'stream-progress', _streamChunkPayload);
+        runParallelHook('onStreamChunk', _streamChunkPayload);
       } catch {}
       try { res.writeHead(204); res.end(); } catch {}
     });


### PR DESCRIPTION
  ## Summary

  - Add `onStreamChunk` parallel hook to plugin system, fired during `/api/stream-chunk` processing
  - Enables plugins to receive real-time streaming content blocks from Claude Code API responses
  - Used by the http-api plugin to implement `GET /api/plugin/stream` SSE endpoint for remote streaming

  ## Changes

  - `lib/plugin-loader.js`: Add `onStreamChunk: 'parallel'` to `HOOK_TYPES` (+1 line)
  - `server.js`: Call `runParallelHook('onStreamChunk', payload)` after `sendEventToClients('stream-progress')` (+3 lines)

  ## Use Case

  The ccv-remote plugin uses this hook to build a dedicated SSE endpoint (`/api/plugin/stream`) that streams Claude Code's output to remote consumers (e.g., openclaw → DingTalk). Previously, plugins could only detect completed entries via `onNewEntry`, missing real-time streaming chunks.