### PR TITLE
fix: support HTTPS for live-stream chunk delivery

### DIFF
--- a/interceptor.js
+++ b/interceptor.js
@@ -8,6 +8,7 @@ const _ccvSkip = _ccvSkipArgs.includes(process.argv[2]);
 import './lib/proxy-env.js';
 import { appendFileSync, mkdirSync, readFileSync, writeFileSync, statSync, renameSync, unlinkSync, existsSync, watchFile } from 'node:fs';
 import http from 'node:http';
+import https from 'node:https';
 import { homedir } from 'node:os';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { dirname, join, basename } from 'node:path';
@@ -23,7 +24,8 @@ const __dirname = dirname(__filename);
 // 不用 process.env.CCVIEWER_PORT 是为了避免主进程 env 污染被 child_process.spawn
 // 继承到 Bash 工具子进程 / MCP server / Electron tab-worker 等无关进程。
 let _livePort = null;
-export function setLivePort(port) { _livePort = port ? String(port) : null; }
+let _liveProtocol = 'http';
+export function setLivePort(port, protocol) { _livePort = port ? String(port) : null; _liveProtocol = protocol || 'http'; }
 
 // 流式请求的实时状态（供 server.js SSE 推送）
 export const streamingState = { active: false, requestId: null, startTime: null, model: null, bytesReceived: 0, chunksReceived: 0 };
@@ -403,7 +405,8 @@ export function sendStreamChunk(entry, chunkSeq, onDone) {
   if (!port) return;
   try {
     const payload = JSON.stringify({ ...entry, _chunkSeq: chunkSeq });
-    const req = http.request({
+    const mod = _liveProtocol === 'https' ? https : http;
+    const req = mod.request({
       hostname: '127.0.0.1',
       port: Number(port),
       path: '/api/stream-chunk',
@@ -414,6 +417,7 @@ export function sendStreamChunk(entry, chunkSeq, onDone) {
         'x-cc-viewer-internal': '1',
       },
       timeout: 500,
+      rejectUnauthorized: false,
     }, (res) => {
       // 413 = payload too large → notify caller to stop sending further chunks
       if (onDone) onDone(res.statusCode !== 413);

--- a/server.js
+++ b/server.js
@@ -3260,7 +3260,7 @@ export async function startViewer() {
           // interceptor.js runs in this same process (via proxy.js → setupInterceptor).
           // Inject live-port via module-level setter instead of process.env to avoid
           // polluting env of child_process.spawn descendants (Bash tools / MCP / Electron tabs).
-          setLivePort(port);
+          setLivePort(port, serverProtocol);
           const url = `${serverProtocol}://127.0.0.1:${port}`;
           if (!isCliMode) {
             console.error(t('server.started'));


### PR DESCRIPTION
sendStreamChunk used http.request unconditionally, which silently fails when the server listens on HTTPS (self-signed cert). This breaks the onStreamChunk plugin hook — no content_delta SSE events are broadcast during streaming.

- Add https import and _liveProtocol state to interceptor
- setLivePort now accepts optional protocol parameter
- sendStreamChunk selects http/https module based on _liveProtocol
- server.js passes serverProtocol to setLivePort on listen