### PR TITLE
fix: allow pasted upload previews on macOS

### DIFF
--- a/lib/file-access-policy.js
+++ b/lib/file-access-policy.js
@@ -16,7 +16,9 @@ import { homedir, platform, tmpdir } from 'node:os';
 import { getClaudeConfigDir } from '../findcc.js';
 import { loadWorkspaces } from '../workspace-registry.js';
 
-const isWin = platform() === 'win32';
+const osPlatform = platform();
+const isWin = osPlatform === 'win32';
+const isDarwin = osPlatform === 'darwin';
 const norm = (p) => isWin ? p.toLowerCase() : p;
 const withSep = (p) => p.endsWith(sep) ? p : p + sep;
 
@@ -126,6 +128,7 @@ function computeRoots() {
   add(STARTUP_CWD);
   add(getClaudeConfigDir());
   add(join(tmpdir(), 'cc-viewer-uploads'));
+  if (isDarwin) add('/private/tmp/cc-viewer-uploads');
   add('/tmp/cc-viewer-uploads');             // Linux/旧上传写入路径(macOS realpath 后 /private/tmp/...)
   add(homeJoin('.claude', 'cc-viewer'));
   try {

--- a/server.js
+++ b/server.js
@@ -10,7 +10,7 @@ import { execFile, exec, spawn } from 'node:child_process';
 import { promisify } from 'node:util';
 import { Worker } from 'node:worker_threads';
 import { isPathContained, ERROR_STATUS_MAP, validateImportDir } from './lib/file-api.js';
-import { isReadAllowed, reasonToStatus } from './lib/file-access-policy.js';
+import { isReadAllowed, reasonToStatus, bumpWorkspacesVersion } from './lib/file-access-policy.js';
 
 const execFileAsync = promisify(execFile);
 const execAsync = promisify(exec);
@@ -415,6 +415,7 @@ async function handleRequest(req, res) {
         const fileData = bodyEnd !== -1 ? buf.slice(bodyStart, bodyEnd) : buf.slice(bodyStart);
         const uploadDir = '/tmp/cc-viewer-uploads';
         mkdirSync(uploadDir, { recursive: true });
+        bumpWorkspacesVersion();
         // Unique filename: prepend timestamp to avoid silent overwrite
         const ts = Date.now();
         const dotIdx = originalName.lastIndexOf('.');

--- a/test/file-access-policy.test.js
+++ b/test/file-access-policy.test.js
@@ -77,7 +77,7 @@ process.env.CCV_PROJECT_DIR = PROJECT;
 
 // dynamic import:env 设置后再加载 policy
 const policy = await import('../lib/file-access-policy.js');
-const { isReadAllowed, _resetCacheForTests } = policy;
+const { isReadAllowed, getAllowedRoots, _resetCacheForTests } = policy;
 _resetCacheForTests();
 
 after(() => {
@@ -136,6 +136,15 @@ describe('file-access-policy: allowlist 命中', () => {
         || r.real === '/tmp/cc-viewer-uploads/foo-test-policy.png',
         `unexpected real: ${r.real}`);
     }
+  });
+
+  it('macOS 显式包含 /private/tmp 上传目录,覆盖 upload dir 启动后才创建的场景', { skip: process.platform !== 'darwin' }, () => {
+    _resetCacheForTests();
+    const roots = getAllowedRoots();
+    assert.ok(
+      roots.some(r => r.raw === '/private/tmp/cc-viewer-uploads'),
+      JSON.stringify(roots)
+    );
   });
 });
 


### PR DESCRIPTION
## Summary
- include the macOS real path for `/tmp/cc-viewer-uploads` in the file-access allowlist
- invalidate the cached allowlist after the upload directory is created
- add a Darwin regression assertion for the `/private/tmp` upload root

## Why
On macOS, `/tmp` resolves to `/private/tmp`. If cc-viewer computes file-access roots before `/tmp/cc-viewer-uploads` exists, pasted image uploads can be saved successfully but later rejected by `/api/file-raw` with `outside-allowlist`, causing broken image previews.

## Tests
- `node --check server.js`
- `node --check lib/file-access-policy.js`
- `node --test test/file-access-policy.test.js`
- `node --test test/upload-api.test.js`
- `npm test` *(1590/1591 passed; unrelated `test/findcc.test.js` subprocess timed out after 5s in `resolveNativePath ~/.claude/ CLAUDE_CONFIG_DIR rewrite`)*
