### PR TITLE
Fix zstd Accept-Encoding sanitization

### DIFF
--- a/interceptor.js
+++ b/interceptor.js
@@ -13,7 +13,7 @@ import { homedir } from 'node:os';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { dirname, join, basename } from 'node:path';
 import { LOG_DIR } from './findcc.js';
-import { assembleStreamMessage, createStreamAssembler, cleanupTempFiles, findRecentLog, isAnthropicApiPath, isMainAgentRequest, rotateLogFile, fingerprintMsg } from './lib/interceptor-core.js';
+import { assembleStreamMessage, createStreamAssembler, cleanupTempFiles, findRecentLog, isAnthropicApiPath, isMainAgentRequest, rotateLogFile, fingerprintMsg, stripZstdAcceptEncoding } from './lib/interceptor-core.js';
 
 
 
@@ -745,6 +745,15 @@ export function setupInterceptor() {
 
     let response;
     try {
+      // 剥掉 accept-encoding 里的 zstd —— Node <= 22 (undici 6.x) 不自动解压 zstd，
+      // 让上游选了 zstd 会导致 response 透传压缩字节，下游 JSON 解析全部 fail。
+      // gzip/br/deflate 各版本通吃，删 zstd 是最低成本的兼容修复。
+      if (_fetchOpts?.headers) {
+        const cleanedHeaders = stripZstdAcceptEncoding(_fetchOpts.headers);
+        if (cleanedHeaders !== _fetchOpts.headers) {
+          _fetchOpts = { ..._fetchOpts, headers: cleanedHeaders };
+        }
+      }
       response = await _originalFetch.call(this, _fetchUrl, _fetchOpts);
     } catch (err) {
       if (requestEntry?.isStream) resetStreamingState();

--- a/lib/interceptor-core.js
+++ b/lib/interceptor-core.js
@@ -375,6 +375,55 @@ export function fingerprintMsg(m) {
 }
 
 /**
+ * Strip `zstd` from an outbound `accept-encoding` header.
+ *
+ * Why: Node <= 22 ships undici 6.x, which doesn't auto-decompress zstd. If the
+ * upstream picks zstd from our offer, the response bytes flow through as raw
+ * compressed garbage and downstream JSON parsing blows up. gzip/br/deflate are
+ * universally handled, so removing zstd from the offer is the cheapest
+ * cross-version fix.
+ *
+ * Returns the input unchanged when no change is needed (for cheap reference
+ * equality at the call site). Handles plain objects and Headers instances;
+ * preserves the original key casing (`Accept-Encoding` vs `accept-encoding`).
+ */
+export function stripZstdAcceptEncoding(headers) {
+  if (!headers) return headers;
+  const cleanValue = (v) => {
+    if (typeof v !== 'string') return null;
+    let removed = false;
+    const cleaned = v.split(',').map(s => s.trim()).filter(s => {
+      if (!s) return false;
+      const encoding = s.split(';', 1)[0].trim();
+      if (encoding.toLowerCase() !== 'zstd') return true;
+      removed = true;
+      return false;
+    }).join(', ');
+    return removed ? cleaned : null;
+  };
+  if (typeof Headers !== 'undefined' && headers instanceof Headers) {
+    const v = headers.get('accept-encoding');
+    const cleaned = cleanValue(v);
+    if (cleaned === null) return headers;
+    const next = new Headers(headers);
+    if (cleaned) next.set('accept-encoding', cleaned);
+    else next.delete('accept-encoding');
+    return next;
+  }
+  if (typeof headers === 'object') {
+    const key = Object.keys(headers).find(k => k.toLowerCase() === 'accept-encoding');
+    if (!key) return headers;
+    const cleaned = cleanValue(headers[key]);
+    if (cleaned === null) return headers;
+    const next = { ...headers };
+    if (cleaned) next[key] = cleaned;
+    else delete next[key];
+    return next;
+  }
+  return headers;
+}
+
+/**
  * Rotate log file when it exceeds maxSize.
  * Creates an empty new file (no content migration) and appends '\n' to old file
  * to trigger fs.watchFile callback for watcher migration.

--- a/test/interceptor.test.js
+++ b/test/interceptor.test.js
@@ -13,6 +13,7 @@ import {
   isPreflightEntry,
   migrateConversationContext,
   rotateLogFile,
+  stripZstdAcceptEncoding,
 } from '../lib/interceptor-core.js';
 
 // ============================================================================
@@ -859,6 +860,71 @@ describe('interceptor', () => {
 
       const result = rotateLogFile(oldFile, newFile, 500);
       assert.equal(result.rotated, true);
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // stripZstdAcceptEncoding
+  // --------------------------------------------------------------------------
+  describe('stripZstdAcceptEncoding', () => {
+    it('removes zstd from a comma-separated list and keeps others', () => {
+      const out = stripZstdAcceptEncoding({ 'accept-encoding': 'gzip, br, zstd' });
+      assert.equal(out['accept-encoding'], 'gzip, br');
+    });
+
+    it('deletes the header entirely when zstd was the only value', () => {
+      const out = stripZstdAcceptEncoding({ 'accept-encoding': 'zstd' });
+      assert.equal('accept-encoding' in out, false);
+    });
+
+    it('returns the same reference when the header has no zstd (no-op fast path)', () => {
+      const input = { 'accept-encoding': 'gzip, br' };
+      assert.equal(stripZstdAcceptEncoding(input), input);
+    });
+
+    it('returns the same reference when the header is missing', () => {
+      const input = { 'content-type': 'application/json' };
+      assert.equal(stripZstdAcceptEncoding(input), input);
+    });
+
+    it('preserves the original key casing', () => {
+      const out = stripZstdAcceptEncoding({ 'Accept-encoding': 'gzip, zstd, br' });
+      assert.equal(out['Accept-encoding'], 'gzip, br');
+      assert.equal('accept-encoding' in out, false, 'must not duplicate under lowercase');
+    });
+
+    it('matches zstd case-insensitively', () => {
+      const out = stripZstdAcceptEncoding({ 'accept-encoding': 'gzip, ZSTD' });
+      assert.equal(out['accept-encoding'], 'gzip');
+    });
+
+    it('removes zstd entries with parameters', () => {
+      const out = stripZstdAcceptEncoding({ 'accept-encoding': 'gzip, zstd;q=1, br' });
+      assert.equal(out['accept-encoding'], 'gzip, br');
+    });
+
+    it('does not mutate the input object', () => {
+      const input = { 'accept-encoding': 'gzip, zstd' };
+      stripZstdAcceptEncoding(input);
+      assert.equal(input['accept-encoding'], 'gzip, zstd');
+    });
+
+    it('handles Headers instance', () => {
+      const h = new Headers({ 'accept-encoding': 'gzip, zstd, br' });
+      const out = stripZstdAcceptEncoding(h);
+      assert.notEqual(out, h, 'should return a new Headers instance');
+      assert.equal(out.get('accept-encoding'), 'gzip, br');
+    });
+
+    it('handles Headers instance with only zstd: deletes headers', () => {
+      const h = new Headers({ 'accept-encoding': 'zstd' });
+      const out = stripZstdAcceptEncoding(h);
+      assert.equal(out.get('accept-encoding'), null);
+    });
+
+    it('returns falsy input unchanged', () => {
+      assert.equal(stripZstdAcceptEncoding(null), null);
+      assert.equal(stripZstdAcceptEncoding(undefined), undefined);
     });
   });
 });


### PR DESCRIPTION
## Summary
- strip zstd Accept-Encoding entries even when they include parameters like q-values
- preserve existing header object behavior for no-op cases and Headers instances
- add regression coverage for zstd;q=1

## Tests
- npm test