### PR TITLE
fix(windows): 临时终端/主终端 Windows 默认 shell 选择

### DIFF
--- a/pty-manager.js
+++ b/pty-manager.js
@@ -343,7 +343,7 @@ export async function spawnShell() {
 
   fixSpawnHelperPermissions();
 
-  const shell = process.env.SHELL || '/bin/sh';
+  const shell = process.env.SHELL || (process.platform === 'win32' ? (process.env.ComSpec || 'cmd.exe') : '/bin/sh');
 
   lastExitCode = null;
   currentWorkspacePath = cwd;

--- a/scratch-pty-manager.js
+++ b/scratch-pty-manager.js
@@ -124,7 +124,7 @@ export async function spawnScratch(id) {
     const pty = await getPty();
     fixSpawnHelperPermissions();
 
-    const shell = process.env.SHELL || '/bin/sh';
+    const shell = process.env.SHELL || (process.platform === 'win32' ? (process.env.ComSpec || 'cmd.exe') : '/bin/sh');
     const env = { ...process.env };
     // 前缀扫描剥离 cc-viewer 主进程的全部协调变量，scratch shell 只继承 cwd + 通用 shell env。
     // cli.js 会在父进程 set 一批 CCV_*（CCV_CLI_MODE / CCV_PROJECT_DIR / CCV_PROXY_PORT / CCV_SDK_MODE /
@@ -278,5 +278,5 @@ export function hasScratchPty(id) {
 
 // 当前 spawn 用的 shell basename（zsh / bash / fish 等），供前端渲染 tab 标签
 export function getScratchShellBasename() {
-  return basename(process.env.SHELL || '/bin/sh') || 'shell';
+  return basename(process.env.SHELL || (process.platform === 'win32' ? (process.env.ComSpec || 'cmd.exe') : '/bin/sh')) || 'shell';
 }

--- a/test/scratch-pty-manager.test.js
+++ b/test/scratch-pty-manager.test.js
@@ -160,8 +160,10 @@ describe('scratch-pty-manager: embedded shell env', () => {
 });
 
 describe('scratch-pty-manager: Windows shell fallback', () => {
-  it('spawns cmd.exe when SHELL is unset on Windows', async () => {
-    if (process.platform !== 'win32') return;
+  it('spawns cmd.exe when SHELL is unset on Windows', async (t) => {
+    if (process.platform !== 'win32') {
+      t.skip('Windows only');
+    }
     const prevShell = process.env.SHELL;
     const prevComSpec = process.env.ComSpec;
     const spawned = [];
@@ -198,8 +200,10 @@ describe('scratch-pty-manager: Windows shell fallback', () => {
     }
   });
 
-  it('getScratchShellBasename returns cmd.exe when SHELL is unset on Windows', () => {
-    if (process.platform !== 'win32') return;
+  it('getScratchShellBasename returns cmd.exe when SHELL is unset on Windows', (t) => {
+    if (process.platform !== 'win32') {
+      t.skip('Windows only');
+    }
     const prevShell = process.env.SHELL;
     delete process.env.SHELL;
     try {

--- a/test/scratch-pty-manager.test.js
+++ b/test/scratch-pty-manager.test.js
@@ -13,6 +13,7 @@ import {
   getScratchOutputBuffer,
   getScratchStartupCwd,
   getScratchActiveCount,
+  getScratchShellBasename,
   _setPtyImportForTests,
 } from '../scratch-pty-manager.js';
 
@@ -154,6 +155,58 @@ describe('scratch-pty-manager: embedded shell env', () => {
       else process.env.CLAUDE_CODE_NO_FLICKER = prevNoFlicker;
       if (prevKeep === undefined) delete process.env.CCV_KEEP_CLAUDE_CODE_NO_FLICKER;
       else process.env.CCV_KEEP_CLAUDE_CODE_NO_FLICKER = prevKeep;
+    }
+  });
+});
+
+describe('scratch-pty-manager: Windows shell fallback', () => {
+  it('spawns cmd.exe when SHELL is unset on Windows', async () => {
+    if (process.platform !== 'win32') return;
+    const prevShell = process.env.SHELL;
+    const prevComSpec = process.env.ComSpec;
+    const spawned = [];
+    delete process.env.SHELL;
+    delete process.env.ComSpec;
+
+    _setPtyImportForTests(() => ({
+      spawn(command, args, opts) {
+        const inst = {
+          pid: 9999,
+          command,
+          args,
+          opts,
+          write() {},
+          resize() {},
+          kill() {},
+          onData() {},
+          onExit() {},
+        };
+        spawned.push(inst);
+        return inst;
+      },
+    }));
+
+    try {
+      await spawnScratch('win-shell-test');
+      assert.equal(spawned.length, 1);
+      assert.equal(spawned[0].command, 'cmd.exe');
+    } finally {
+      if (prevShell !== undefined) process.env.SHELL = prevShell;
+      else delete process.env.SHELL;
+      if (prevComSpec !== undefined) process.env.ComSpec = prevComSpec;
+      else delete process.env.ComSpec;
+    }
+  });
+
+  it('getScratchShellBasename returns cmd.exe when SHELL is unset on Windows', () => {
+    if (process.platform !== 'win32') return;
+    const prevShell = process.env.SHELL;
+    delete process.env.SHELL;
+    try {
+      assert.equal(getScratchShellBasename(), 'cmd.exe');
+    } finally {
+      if (prevShell !== undefined) process.env.SHELL = prevShell;
+      else delete process.env.SHELL;
     }
   });
 });


### PR DESCRIPTION
Fixes #86

## 问题

在 Windows 上点击「临时终端」按钮时，提示 `scratch spawn failed: File not found`。

根因：`scratch-pty-manager.js` 与 `pty-manager.js` 中默认 shell 选择硬编码为 `process.env.SHELL || '/bin/sh'`。Windows 上 `SHELL` 环境变量通常不存在，fallback 到 `/bin/sh` 后 `node-pty` 无法找到该文件，导致 spawn 失败。

## 修复

将默认 shell 选择改为平台感知：
- **Windows**: `process.env.SHELL || process.env.ComSpec || 'cmd.exe'`
- **Unix/macOS**: 保持原有 `process.env.SHELL || '/bin/sh'`

修改文件：
- `scratch-pty-manager.js` — `spawnScratch` + `getScratchShellBasename`
- `pty-manager.js` — `spawnShell`

## 测试

- `npm run test` 全部通过（52/52 相关测试绿，含新增 2 条 Windows shell fallback 回归测试）
- `npm run build` 构建成功

## 复现环境

Windows 11 + cc-viewer 本地部署，web 端点击「临时终端」按钮。