### PR TITLE
fix(diff): 统一 CRLF 换行符归一化并修复 diff 视图 HTML 转义

### DIFF
--- a/lib/git-diff.js
+++ b/lib/git-diff.js
@@ -299,6 +299,10 @@ export async function getGitDiffs(cwd, files, commitHash) {
             }
           }
         }
+
+        // 统一换行符，避免 Windows CRLF 与 Git LF 差异导致整文件被标记为变更
+        old_content = old_content.replace(/\r\n/g, '\n');
+        new_content = new_content.replace(/\r\n/g, '\n');
       }
 
       diffs.push({

--- a/src/components/DiffView.jsx
+++ b/src/components/DiffView.jsx
@@ -7,7 +7,9 @@ import styles from './DiffView.module.css';
 const { Text } = Typography;
 
 function computeDiffLines(oldStr, newStr, startLine) {
-  const changes = Diff.diffLines(oldStr, newStr);
+  const normalizedOld = (oldStr || '').replace(/\r\n/g, '\n');
+  const normalizedNew = (newStr || '').replace(/\r\n/g, '\n');
+  const changes = Diff.diffLines(normalizedOld, normalizedNew);
   const lines = [];
   let oldLineNum = startLine;
   let newLineNum = startLine;

--- a/src/components/FullFileDiffView.jsx
+++ b/src/components/FullFileDiffView.jsx
@@ -100,10 +100,13 @@ function escapeHtml(text) {
 
 function highlightLines(content, lang) {
   if (!content) return [];
-  const lines = content.split('\n');
+  // 与 computeDiffLines 保持一致：CRLF 归一化后再切行，
+  // 否则带 \r 的行会跟随 dl.html 渲染到 DOM，复制粘贴会带出 CR。
+  const normalized = content.replace(/\r\n/g, '\n');
+  const lines = normalized.split('\n');
   if (lang) {
     try {
-      const highlighted = hljs.highlight(content, { language: lang });
+      const highlighted = hljs.highlight(normalized, { language: lang });
       return highlighted.value.split('\n');
     } catch {
       return lines.map(line => escapeHtml(line));

--- a/src/components/FullFileDiffView.jsx
+++ b/src/components/FullFileDiffView.jsx
@@ -91,6 +91,13 @@ function getLanguage(filePath) {
   return LANG_MAP[ext] || null;
 }
 
+function escapeHtml(text) {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
 function highlightLines(content, lang) {
   if (!content) return [];
   const lines = content.split('\n');
@@ -99,14 +106,16 @@ function highlightLines(content, lang) {
       const highlighted = hljs.highlight(content, { language: lang });
       return highlighted.value.split('\n');
     } catch {
-      return lines;
+      return lines.map(line => escapeHtml(line));
     }
   }
-  return lines;
+  return lines.map(line => escapeHtml(line));
 }
 
 function computeDiffLines(oldStr, newStr) {
-  const changes = Diff.diffLines(oldStr, newStr);
+  const normalizedOld = (oldStr || '').replace(/\r\n/g, '\n');
+  const normalizedNew = (newStr || '').replace(/\r\n/g, '\n');
+  const changes = Diff.diffLines(normalizedOld, normalizedNew);
   const lines = [];
   let oldLineNum = 1;
   let newLineNum = 1;
@@ -162,14 +171,14 @@ export default function FullFileDiffView({ file_path, old_string, new_string }) 
   const diffLines = useMemo(() => {
     if (isNew) {
       // 新文件：所有行都是 add
-      const lines = (new_string || '').split('\n');
+      const lines = (new_string || '').replace(/\r\n/g, '\n').split('\n');
       return lines.map((text, i) => ({
         type: 'add', oldNum: null, newNum: i + 1, text
       }));
     }
     if (isDeleted) {
       // 删除文件：所有行都是 del
-      const lines = (old_string || '').split('\n');
+      const lines = (old_string || '').replace(/\r\n/g, '\n').split('\n');
       return lines.map((text, i) => ({
         type: 'del', oldNum: i + 1, newNum: null, text
       }));

--- a/test/git-diff.test.js
+++ b/test/git-diff.test.js
@@ -116,6 +116,19 @@ describe('getGitDiffs', () => {
     assert.equal(result[0].is_large, true);
     assert.ok(result[0].size > 5 * 1024 * 1024);
   });
+
+  it('normalizes CRLF to LF so diff does not treat line endings as changes', async () => {
+    writeFileSync(join(cwd, 'crlf.txt'), 'line1\nline2\nline3');
+    execSync('git add crlf.txt && git commit -m "add"', { cwd, stdio: 'pipe' });
+    // Overwrite with CRLF — only real change is "line2" → "modified"
+    writeFileSync(join(cwd, 'crlf.txt'), 'line1\r\nmodified\r\nline3');
+    const result = await getGitDiffs(cwd, ['crlf.txt']);
+    assert.equal(result.length, 1);
+    assert.equal(result[0].status, 'M');
+    // Both contents should be normalized to LF
+    assert.equal(result[0].old_content, 'line1\nline2\nline3');
+    assert.equal(result[0].new_content, 'line1\nmodified\nline3');
+  });
 });
 
 describe('countUntrackedLines', () => {


### PR DESCRIPTION
## Summary

- 修复 Windows 上 CRLF 与 Git LF 差异导致整文件被标记为变更的问题。
- 后端 `getGitDiffs` 与前端 `DiffView` / `FullFileDiffView` 在 diff 计算前统一将 `\r\n` 归一化为 `\n`。
- `FullFileDiffView` 增加 `escapeHtml`，对无语法高亮的行做 `& < >` 转义，防止 `dangerouslySetInnerHTML` 渲染注入。
- 新增 `git-diff.test.js` CRLF 归一化测试用例。

## Test plan

- [x] `node --test test/git-diff.test.js` 全部通过（29 tests pass）
- [x] `npm run build` 生产构建无报错

🤖 Generated with [Claude Code](https://claude.com/claude-code)