### PR TITLE
fix(file-browser): classify symlinked directories as directories

### DIFF
--- a/server.js
+++ b/server.js
@@ -1032,7 +1032,18 @@ async function handleRequest(req, res) {
       const entries = readdirSync(targetDir, { withFileTypes: true });
       const items = entries
         .filter(e => !IGNORED_PATTERNS.has(e.name))
-        .map(e => ({ name: e.name, type: e.isDirectory() ? 'directory' : 'file' }))
+        .map(e => {
+          // Dirent.isDirectory() 不解引用 symlink —— 对指向目录的 symlink 也返回 false。
+          // 需要对 symlink 单独 statSync（follow link）才能拿到真实类型，否则前端会把
+          // symlink-to-dir 当成文件渲染，不可展开。断链时 fallback 到 file，避免单个
+          // 坏链接让整个目录返回 404。
+          let type = e.isDirectory() ? 'directory' : 'file';
+          if (e.isSymbolicLink()) {
+            try { type = statSync(join(targetDir, e.name)).isDirectory() ? 'directory' : 'file'; }
+            catch { type = 'file'; }
+          }
+          return { name: e.name, type };
+        })
         .sort((a, b) => {
           if (a.type !== b.type) return a.type === 'directory' ? -1 : 1;
           return a.name.localeCompare(b.name);


### PR DESCRIPTION
## Summary

When the project root contains symlinks pointing to directories, the file browser at `/api/files` reports them with `type: 'file'`, so the front-end renders them with a file icon and they can't be expanded.

## Repro

```sh
mkdir -p /tmp/real-target/sub
mkdir -p /tmp/proj && cd /tmp/proj
ln -s /tmp/real-target linked
CCV_PROJECT_DIR=/tmp/proj ccv -c
# open http://127.0.0.1:7014/  →  `linked` shows as a file
```

`curl 'http://127.0.0.1:7014/api/files?path=.'` before fix:

```json
[{ "name": "linked", "type": "file" }]
```

After fix:

```json
[{ "name": "linked", "type": "directory" }]
```

## Root cause

`server.js` `/api/files` handler uses:

```js
const entries = readdirSync(targetDir, { withFileTypes: true });
const items = entries
  .filter(e => !IGNORED_PATTERNS.has(e.name))
  .map(e => ({ name: e.name, type: e.isDirectory() ? 'directory' : 'file' }))
```

With `withFileTypes: true`, `Dirent.isDirectory()` reports the **link itself**, not its target — for any symlink it returns `false` regardless of what the link points to. So `symlink → dir` gets classified as a file.

## Fix

Detect symlinks via `isSymbolicLink()` and `statSync` the target (which follows the link) to get the real type. Broken links fall back to `'file'` so a single dangling link doesn't 404 the whole listing.

```js
.map(e => {
  let type = e.isDirectory() ? 'directory' : 'file';
  if (e.isSymbolicLink()) {
    try { type = statSync(join(targetDir, e.name)).isDirectory() ? 'directory' : 'file'; }
    catch { type = 'file'; }
  }
  return { name: e.name, type };
})
```

`statSync` and `join` are already imported.

## Test plan

- [x] Manual repro in a project containing four symlink-to-dir entries — all four now render as expandable folders, can drill in and read files; the `nanobot-config.json` symlink (pointing to a file) stays as a file.
- [x] Verified `curl /api/files?path=.` output before / after.
- [ ] Broken symlink: synthetic `ln -s /nonexistent foo` — falls back to `type: 'file'` instead of crashing the listing (recommended to verify).

## Env

- cc-viewer `main` (HEAD `a7308bb`)
- Node v22.22.0, macOS Darwin 25.5.0 — bug is OS-independent (it's how `Dirent.isDirectory()` is specified).