### PR TITLE
fix(terminal): 暗色主题 scratch 终端光标不可见

### DIFF
--- a/src/components/terminal/terminalThemes.js
+++ b/src/components/terminal/terminalThemes.js
@@ -1,6 +1,6 @@
 // 抽离自 TerminalPanel.jsx，供 TerminalPanel + ScratchTerminal 共用，破除循环 import。
 export const darkTerminalTheme = {
-  background: '#0a0a0a', foreground: '#d4d4d4', cursor: '#0a0a0a',
+  background: '#0a0a0a', foreground: '#d4d4d4', cursor: '#d4d4d4',
   selectionBackground: '#264f78',
   black: '#000000', red: '#ef4444', green: '#73c991', yellow: '#fbbf24',
   blue: '#3b82f6', magenta: '#d946ef', cyan: '#06b6d4', white: '#e5e5e5',


### PR DESCRIPTION
cursor 颜色 (#0a0a0a) 与 background 相同，DOM/Canvas 渲染器的 bar 光标使用 box-shadow 渲染，导致光标完全不可见。主终端因
使用 WebGL addon 不受影响，scratch 终端无 WebGL 故光标消失。
将 cursor 颜色改为与 foreground 一致 (#d4d4d4)。

