### PR TITLE
fix(proxy): Node 26 起代理转发绕过 http_proxy 回归 + 压缩响应错配致 CLI 报错

### DIFF
--- a/history.md
+++ b/history.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- fix(proxy): 代理转发改为把 `EnvHttpProxyAgent` 显式作为 `fetch` 的 `dispatcher` 传入——Node 内置全局 `fetch` 用的是 Node 自带的那份 undici,与 userland undici 包的 `setGlobalDispatcher` 互不相通,旧实现只调 `setGlobalDispatcher` 导致转发请求绕过 `http_proxy`/`https_proxy` 直连 `api.anthropic.com`(配了网络代理却不生效);新增 `getProxyDispatcher()` 暴露已构造的 dispatcher 供转发处显式传入,`setGlobalDispatcher` 仍保留以覆盖直接 `import 'undici'` 的调用路径;补 `getProxyDispatcher` 单测
+- fix(proxy): 代理转发改为把 `EnvHttpProxyAgent` 显式作为 `fetch` 的 `dispatcher` 传入——**Node 26 起的回归**:转发用的内置全局 `fetch` 背后是 Node 自带的 undici,Node ≤25 时它与 userland undici 包共享 global dispatcher(故旧代码一直好用),实测 Node 26 起两者不再共享,单调 `setGlobalDispatcher` 失效,转发请求绕过 `http_proxy`/`https_proxy` 直连 `api.anthropic.com`(配了网络代理却不生效);新增 `getProxyDispatcher()` 暴露已构造的 dispatcher 供转发处显式传入(各 Node 版本通用),`setGlobalDispatcher` 仍保留以覆盖直接 `import 'undici'` 的调用路径;补 `getProxyDispatcher` 单测
 - fix(proxy): 上游请求强制 `accept-encoding: identity` 取代仅剥 zstd 的旧策略——链路中的网关/代理可能透传上游的压缩 body 却剥掉 `content-encoding` 响应头,undici 看不到该头就不解压,把压缩字节当明文透传给 Claude CLI,触发 "API returned an empty or malformed response (HTTP 200)";让上游直接不压缩即从根上消除这类错配;删除已被取代的死代码 `stripZstdAcceptEncoding`,新增 `forceIdentityAcceptEncoding` 单测
 
 ## 1.6.282 (2026-05-29)

--- a/history.md
+++ b/history.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- fix(proxy): 代理转发改为把 `EnvHttpProxyAgent` 显式作为 `fetch` 的 `dispatcher` 传入——Node 内置全局 `fetch` 用的是 Node 自带的那份 undici,与 userland undici 包的 `setGlobalDispatcher` 互不相通,旧实现只调 `setGlobalDispatcher` 导致转发请求绕过 `http_proxy`/`https_proxy` 直连 `api.anthropic.com`(配了网络代理却不生效);新增 `getProxyDispatcher()` 暴露已构造的 dispatcher 供转发处显式传入,`setGlobalDispatcher` 仍保留以覆盖直接 `import 'undici'` 的调用路径;补 `getProxyDispatcher` 单测
+- fix(proxy): 上游请求强制 `accept-encoding: identity` 取代仅剥 zstd 的旧策略——链路中的网关/代理可能透传上游的压缩 body 却剥掉 `content-encoding` 响应头,undici 看不到该头就不解压,把压缩字节当明文透传给 Claude CLI,触发 "API returned an empty or malformed response (HTTP 200)";让上游直接不压缩即从根上消除这类错配;删除已被取代的死代码 `stripZstdAcceptEncoding`,新增 `forceIdentityAcceptEncoding` 单测
+
 ## 1.6.282 (2026-05-29)
 
 - feat(messaging): 通讯软件集成弹窗从左右两栏改为上下布局,IM 工具选择改 Chrome 浏览器头部 tab 风格(选中态顶圆角、底边 2px 同色融进下方内容面板盖住接缝、去掉面板顶边横线消除露线);modal body 取 --bg-elevated 与面板 --bg-container 拉出层次,暗色主题给面板内 antd 输入框补 --bg-elevated 底色避免与面板同色消失;移除"选择要连接的 IM 工具"副标题

--- a/server/lib/proxy-env.js
+++ b/server/lib/proxy-env.js
@@ -10,12 +10,13 @@ export function resolveProxyConfig(env = process.env) {
   };
 }
 
-// 关键坑位：setGlobalDispatcher 只对"userland undici 包"这一实例的全局 dispatcher 生效，
-// 而代理转发上游用的是 Node 内置全局 fetch（背后是 Node 自带的另一份 undici），两份 undici
-// 的 global dispatcher 互不相通。所以单靠 setGlobalDispatcher，代理转发的请求不会读
-// http_proxy/https_proxy，会直连 api.anthropic.com，绕过用户的网络代理。
-// 解法：把这里构造的 EnvHttpProxyAgent 显式保存下来，由 proxy 转发处作为 fetch 的
-// dispatcher 选项传入（Node 内置 fetch 接受 userland undici 的 dispatcher 实例）。
+// 关键坑位（Node 26 起的回归）：代理转发上游用的是 Node 内置全局 fetch，背后是 Node 自带的
+// 那份 undici。Node ≤25 时它与 userland undici 包共享同一个 global dispatcher（Symbol.for
+// 同键），所以单调 setGlobalDispatcher 也能让转发请求走代理——这也是为何旧代码一直好用。
+// 实测 Node 26 起两份 undici 不再共享 global dispatcher，单靠 setGlobalDispatcher，转发请求
+// 读不到 http_proxy/https_proxy，会直连 api.anthropic.com 绕过用户的网络代理。
+// 解法：把这里构造的 EnvHttpProxyAgent 显式保存下来，由 proxy 转发处作为 fetch 的 dispatcher
+// 选项传入（内置 fetch 接受 userland undici 的 dispatcher 实例，各 Node 版本通用）。
 let _proxyDispatcher = null;
 
 export function setupProxyEnv() {

--- a/server/lib/proxy-env.js
+++ b/server/lib/proxy-env.js
@@ -10,14 +10,28 @@ export function resolveProxyConfig(env = process.env) {
   };
 }
 
+// 关键坑位：setGlobalDispatcher 只对"userland undici 包"这一实例的全局 dispatcher 生效，
+// 而代理转发上游用的是 Node 内置全局 fetch（背后是 Node 自带的另一份 undici），两份 undici
+// 的 global dispatcher 互不相通。所以单靠 setGlobalDispatcher，代理转发的请求不会读
+// http_proxy/https_proxy，会直连 api.anthropic.com，绕过用户的网络代理。
+// 解法：把这里构造的 EnvHttpProxyAgent 显式保存下来，由 proxy 转发处作为 fetch 的
+// dispatcher 选项传入（Node 内置 fetch 接受 userland undici 的 dispatcher 实例）。
+let _proxyDispatcher = null;
+
 export function setupProxyEnv() {
   const { httpProxy, httpsProxy, noProxy } = resolveProxyConfig();
   if (!httpProxy && !httpsProxy) return;
 
-  setGlobalDispatcher(new EnvHttpProxyAgent({ httpProxy, httpsProxy, noProxy }));
+  _proxyDispatcher = new EnvHttpProxyAgent({ httpProxy, httpsProxy, noProxy });
+  setGlobalDispatcher(_proxyDispatcher); // 仍保留：覆盖直接 import 'undici' 的 fetch 调用路径
   if (process.env.CCV_DEBUG) {
     console.error(`[CC Viewer] HTTP proxy: http=${httpProxy || '(none)'}, https=${httpsProxy || '(none)'}${noProxy ? `, no_proxy=${noProxy}` : ''}`);
   }
+}
+
+// 返回供"内置全局 fetch"使用的代理 dispatcher；无代理配置时返回 null（调用方不传即直连）。
+export function getProxyDispatcher() {
+  return _proxyDispatcher;
 }
 
 setupProxyEnv();

--- a/server/proxy.js
+++ b/server/proxy.js
@@ -6,26 +6,26 @@ import { homedir } from 'node:os';
 import * as interceptor from './interceptor.js';
 import { setupInterceptor } from './interceptor.js';
 import { extractApiErrorMessage, formatProxyRequestError } from './lib/proxy-errors.js';
+import { getProxyDispatcher } from './lib/proxy-env.js';
 import { getClaudeConfigDir } from '../findcc.js';
 
 // Setup interceptor to patch fetch
 setupInterceptor();
 
-// Node bundled undici 在 22.15 之前不识 zstd；上游若选 zstd 压缩，response.body 会被原样
-// 透传给 Claude CLI，触发 "Failed to parse JSON"。在转发前从 accept-encoding 摘掉 zstd，
-// 让上游回退到 gzip/deflate/br——所有 Node 版本都能正确解。
-export function stripZstdAcceptEncoding(headers) {
+// 强制上游返回未压缩响应，取代仅剥 zstd 的旧策略。
+// 原因：链路中的网关/代理（典型是本地 MITM 网络代理）可能把上游的压缩 body 原样透传，
+// 却把 content-encoding 响应头剥掉。undici 看不到 content-encoding 就不会解压，于是把一坨
+// gzip 字节当明文交回；本代理再把它当 SSE 透传给 Claude CLI →
+// "API returned an empty or malformed response (HTTP 200)"。
+// 让上游直接不压缩，整条链路就没有可被剥离/错配的 content-encoding，从根上消除这类问题。
+export function forceIdentityAcceptEncoding(headers) {
   if (!headers) return headers;
-  const key = Object.keys(headers).find(k => k.toLowerCase() === 'accept-encoding');
-  if (!key) return headers;
-  const val = headers[key];
-  if (typeof val !== 'string' || !/\bzstd\b/i.test(val)) return headers;
-  const filtered = val
-    .split(',')
-    .map(s => s.trim())
-    .filter(s => s && !/^zstd(\s*;.*)?$/i.test(s))
-    .join(', ');
-  return { ...headers, [key]: filtered || 'gzip, deflate, br' };
+  const out = {};
+  for (const k of Object.keys(headers)) {
+    if (k.toLowerCase() !== 'accept-encoding') out[k] = headers[k];
+  }
+  out['accept-encoding'] = 'identity';
+  return out;
 }
 
 // 代理会改写请求 body（interceptor 的模型替换 JSON.parse→改 model→JSON.stringify），
@@ -97,7 +97,7 @@ export function startProxy() {
         // Convert incoming headers
         let headers = { ...req.headers };
         delete headers.host; // Let fetch set the host
-        headers = stripZstdAcceptEncoding(headers);
+        headers = forceIdentityAcceptEncoding(headers); // 让上游不压缩，规避网关剥 content-encoding 头导致的 body 错配
         headers = stripContentLengthHeader(headers); // body 会被改写，旧 content-length 必须丢弃
 
         const buffers = [];
@@ -117,6 +117,14 @@ export function startProxy() {
 
         if (body.length > 0) {
           fetchOptions.body = body;
+        }
+
+        // 走用户的网络代理：Node 内置全局 fetch 既不读 http_proxy/https_proxy，也看不到
+        // userland undici 的 setGlobalDispatcher，必须把代理 dispatcher 显式传进来，否则
+        // 上游请求会绕过代理直连 api.anthropic.com（详见 lib/proxy-env.js 注释）。
+        const proxyDispatcher = getProxyDispatcher();
+        if (proxyDispatcher) {
+          fetchOptions.dispatcher = proxyDispatcher;
         }
 
         // 拼接完整 URL，保留 originalBaseUrl 中的路径前缀

--- a/test/proxy-env.test.js
+++ b/test/proxy-env.test.js
@@ -1,6 +1,7 @@
-import { describe, it } from 'node:test';
+import { describe, it, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
-import { resolveProxyConfig } from '../server/lib/proxy-env.js';
+import { EnvHttpProxyAgent, getGlobalDispatcher, setGlobalDispatcher } from 'undici';
+import { resolveProxyConfig, setupProxyEnv, getProxyDispatcher } from '../server/lib/proxy-env.js';
 
 describe('resolveProxyConfig', () => {
   it('无代理变量时返回全 undefined', () => {
@@ -65,5 +66,31 @@ describe('resolveProxyConfig', () => {
       NO_PROXY: '*.example.com',
     });
     assert.equal(result2.noProxy, '*.example.com');
+  });
+});
+
+describe('getProxyDispatcher / setupProxyEnv', () => {
+  // setupProxyEnv 读 process.env 并调 setGlobalDispatcher，副作用必须隔离：
+  // 用例结束后还原 http_proxy 与全局 dispatcher，避免污染同进程其它用例。
+  const savedHttpProxy = process.env.http_proxy;
+  const savedGlobal = getGlobalDispatcher();
+
+  afterEach(() => {
+    if (savedHttpProxy === undefined) delete process.env.http_proxy;
+    else process.env.http_proxy = savedHttpProxy;
+    setGlobalDispatcher(savedGlobal);
+  });
+
+  it('配置 http_proxy 后 getProxyDispatcher 返回 EnvHttpProxyAgent 实例', () => {
+    process.env.http_proxy = 'http://127.0.0.1:39990';
+    setupProxyEnv();
+    // 这是修复的核心：把代理 dispatcher 暴露出去，供 proxy 转发处显式传给内置 fetch。
+    assert.ok(getProxyDispatcher() instanceof EnvHttpProxyAgent);
+  });
+
+  it('多次调用返回同一引用（稳定 getter，供 fetch dispatcher 复用）', () => {
+    process.env.http_proxy = 'http://127.0.0.1:39990';
+    setupProxyEnv();
+    assert.equal(getProxyDispatcher(), getProxyDispatcher());
   });
 });

--- a/test/proxy.test.js
+++ b/test/proxy.test.js
@@ -60,19 +60,18 @@ function filterResponseHeaders(headerEntries) {
   return filtered;
 }
 
-// Replicated from proxy.js: zstd stripping in upstream request headers
-function stripZstdAcceptEncoding(headers) {
+// Replicated from proxy.js: force upstream to return uncompressed responses.
+// Strips any existing accept-encoding (case-insensitive) and forces identity, so a
+// gateway that drops the content-encoding response header can't leave undici handing
+// back still-compressed bytes that get streamed to the CLI as if they were plaintext.
+function forceIdentityAcceptEncoding(headers) {
   if (!headers) return headers;
-  const key = Object.keys(headers).find(k => k.toLowerCase() === 'accept-encoding');
-  if (!key) return headers;
-  const val = headers[key];
-  if (typeof val !== 'string' || !/\bzstd\b/i.test(val)) return headers;
-  const filtered = val
-    .split(',')
-    .map(s => s.trim())
-    .filter(s => s && !/^zstd(\s*;.*)?$/i.test(s))
-    .join(', ');
-  return { ...headers, [key]: filtered || 'gzip, deflate, br' };
+  const out = {};
+  for (const k of Object.keys(headers)) {
+    if (k.toLowerCase() !== 'accept-encoding') out[k] = headers[k];
+  }
+  out['accept-encoding'] = 'identity';
+  return out;
 }
 
 // Replicated from proxy.js: drop client-declared content-length before forwarding,
@@ -522,61 +521,41 @@ describe('proxy', () => {
     });
   });
 
-  describe('stripZstdAcceptEncoding (zstd workaround for Node<22.15 bundled undici)', () => {
-    it('returns headers untouched when accept-encoding is absent', () => {
-      const input = { 'content-type': 'application/json' };
-      const out = stripZstdAcceptEncoding(input);
-      assert.equal(out, input);
+  describe('forceIdentityAcceptEncoding (force uncompressed upstream to dodge mangled content-encoding)', () => {
+    it('returns input untouched when input is null/undefined', () => {
+      assert.equal(forceIdentityAcceptEncoding(null), null);
+      assert.equal(forceIdentityAcceptEncoding(undefined), undefined);
     });
 
-    it('returns headers untouched when zstd is not listed', () => {
-      const input = { 'accept-encoding': 'gzip, deflate, br' };
-      const out = stripZstdAcceptEncoding(input);
-      assert.equal(out, input);
+    it('adds accept-encoding: identity when the header is absent', () => {
+      const out = forceIdentityAcceptEncoding({ 'content-type': 'application/json' });
+      assert.equal(out['accept-encoding'], 'identity');
+      assert.equal(out['content-type'], 'application/json', 'other headers preserved');
     });
 
-    it('removes zstd while preserving other algorithms (lowercase header)', () => {
-      const out = stripZstdAcceptEncoding({ 'accept-encoding': 'gzip, deflate, br, zstd' });
-      assert.equal(out['accept-encoding'], 'gzip, deflate, br');
+    it('overrides an existing lowercase accept-encoding', () => {
+      const out = forceIdentityAcceptEncoding({ 'accept-encoding': 'gzip, deflate, br, zstd' });
+      assert.equal(out['accept-encoding'], 'identity');
     });
 
-    it('handles TitleCase header key without losing it', () => {
-      const out = stripZstdAcceptEncoding({ 'Accept-Encoding': 'gzip, zstd, br' });
-      assert.equal(out['Accept-Encoding'], 'gzip, br');
-      assert.equal(out['accept-encoding'], undefined);
-    });
-
-    it('strips zstd with q-value', () => {
-      const out = stripZstdAcceptEncoding({ 'accept-encoding': 'gzip;q=1.0, zstd;q=0.9, br;q=0.8' });
-      assert.equal(out['accept-encoding'], 'gzip;q=1.0, br;q=0.8');
-    });
-
-    it('falls back to gzip,deflate,br when zstd is the only token', () => {
-      const out = stripZstdAcceptEncoding({ 'accept-encoding': 'zstd' });
-      assert.equal(out['accept-encoding'], 'gzip, deflate, br');
-    });
-
-    it('does not match substrings like "zstd-foo" or "fzstd"', () => {
-      const out = stripZstdAcceptEncoding({ 'accept-encoding': 'fzstd, gzip' });
-      assert.equal(out['accept-encoding'], 'fzstd, gzip', 'word-boundary regex should not match fzstd');
+    it('drops a TitleCase Accept-Encoding and emits a single lowercase identity', () => {
+      const out = forceIdentityAcceptEncoding({ 'Accept-Encoding': 'gzip, br' });
+      assert.equal(out['Accept-Encoding'], undefined, 'original casing removed');
+      assert.equal(out['accept-encoding'], 'identity');
     });
 
     it('returns a new object (does not mutate input)', () => {
       const input = { 'accept-encoding': 'gzip, zstd' };
-      const out = stripZstdAcceptEncoding(input);
+      const out = forceIdentityAcceptEncoding(input);
       assert.notEqual(out, input);
       assert.equal(input['accept-encoding'], 'gzip, zstd', 'input must remain untouched');
     });
 
-    it('tolerates non-string accept-encoding value (defensive)', () => {
-      const input = { 'accept-encoding': ['gzip', 'zstd'] };
-      const out = stripZstdAcceptEncoding(input);
-      assert.equal(out, input, 'array form left as-is — fetch normalizes upstream');
-    });
-
-    it('returns input untouched when input is null/undefined', () => {
-      assert.equal(stripZstdAcceptEncoding(null), null);
-      assert.equal(stripZstdAcceptEncoding(undefined), undefined);
+    it('preserves unrelated headers alongside the forced identity', () => {
+      const out = forceIdentityAcceptEncoding({ authorization: 'Bearer x', 'x-foo': '1' });
+      assert.equal(out.authorization, 'Bearer x');
+      assert.equal(out['x-foo'], '1');
+      assert.equal(out['accept-encoding'], 'identity');
     });
   });
 


### PR DESCRIPTION
## 背景

ccv 的本地代理(`server/proxy.js`)把 Claude CLI 的请求转发到上游 `ANTHROPIC_BASE_URL`。在「配了网络代理」或「链路中有 MITM 网关」的环境下暴露出两个**相互独立**的 bug,本 PR 各修一个,并补齐单测。

---

## Bug 1:转发请求绕过 `http_proxy`/`https_proxy`,直连 `api.anthropic.com`（**Node 26 起的回归**）

**现象**:用户设了 `http_proxy`/`https_proxy`,但 ccv 转发的上游请求不走代理,直连 `api.anthropic.com`(在需要代理才能出网的环境下表现为转发失败/超时)。

**根因**:转发用的是 **Node 内置全局 `fetch`**,背后是 Node 自带的那份 undici。旧实现靠 userland undici 包的 `setGlobalDispatcher` 来让它走代理。关键在于这是个**版本相关行为**:

- **Node ≤25**:内置 undici 与 userland undici 包共享同一个 global dispatcher(`Symbol.for` 同键),`setGlobalDispatcher` 对内置 `fetch` **生效**,代理正常 → 这也是旧代码一直好用的原因;
- **Node 26 起**:两份 undici 不再共享 global dispatcher,`setGlobalDispatcher` 对内置 `fetch` **失效**,转发请求读不到代理 env,绕过代理直连。

**验证**(同一份旧代码 + undici 7.26,本机逐版本实测):

| Node | `setGlobalDispatcher` 对内置 `fetch` | 代理转发 |
|---|---|---|
| 22.22.3 | 生效 | ✅ 走代理 |
| 24.16.0 | 生效 | ✅ 走代理 |
| 25.9.0 | 生效 | ✅ 走代理 |
| **26.0.0** | **失效** | ❌ **绕过直连** |

补充实验(均在 Node 26):① 用自定义 Agent 经 `setGlobalDispatcher` 占位,内置 `fetch` 的 `dispatch` 从未被调用;② 把 `EnvHttpProxyAgent` 作为 `fetch(url, { dispatcher })` 显式传入 → 经 CONNECT 隧道命中代理 ✅。

**修复**:`proxy-env.js` 新增 `getProxyDispatcher()` 暴露已构造的 `EnvHttpProxyAgent`;`proxy.js` 转发处把它作为 `fetch` 的 `dispatcher` 选项显式传入——这是 undici 文档推荐、**各 Node 版本通用**的方式,Node 26 与 ≤25 都成立。`setGlobalDispatcher` 保留以覆盖直接 `import 'undici'` 的调用路径,对老 Node 无破坏。已确认拦截器(`interceptor.js`)重建 options 时全程 spread,`dispatcher` 键不会被丢,生产链路有效。

> 注:Bug 1 的引入点在代码上是 http_proxy 支持加入时(2026-03,基于 `setGlobalDispatcher`),但**它在 Node ≤25 上一直正常**,真正的触发是升级到 Node 26;故本质是 Node 版本回归,而非代码回归。

---

## Bug 2:压缩响应错配 → `"API returned an empty or malformed response (HTTP 200)"`

**现象**:CLI 报 `API returned an empty or malformed response (HTTP 200)`。

**根因**:转发依赖「undici 按 `content-encoding` 自动解压」。但链路中的网关/代理(典型是本地 MITM 网络代理)可能把上游的压缩 body 原样透传、却剥掉 `content-encoding` 响应头。undici 看不到该头就不解压,把一坨压缩字节当明文交回;本代理再当 SSE 透传给 CLI → 解析失败。旧策略只从 `accept-encoding` 摘 zstd、仍允许 gzip,挡不住这类错配。

**修复**:上游请求强制 `accept-encoding: identity`,让上游直接不压缩。整条链路就没有可被剥离/错配的 `content-encoding`,从根上消除该类问题(以「消除特殊情况」取代「检测并修补错配头」)。代价是放弃响应压缩、增加带宽——对本地调试代理,正确性 > 带宽,可接受。同时删除已被取代的死代码 `stripZstdAcceptEncoding`。

> 注:Bug 2 不是 Node 版本回归——只有当链路里的网关把 `content-encoding` 剥掉/错配时才发作,取决于所连上游/网络环境。「网关剥 `content-encoding`」这一具体机制未在隔离环境复现,属与症状一致的合理推断;但修复不依赖机制是否精确——去掉压缩后这一类错配从根上不存在。

---

## 改动清单

- `server/lib/proxy-env.js`:新增 `getProxyDispatcher()`,保存并暴露 `EnvHttpProxyAgent`;校正注释为 Node 26 版本边界定性。
- `server/proxy.js`:转发 `fetch` 显式传 `dispatcher`;`forceIdentityAcceptEncoding` 取代 `stripZstdAcceptEncoding`(后者删除)。
- `test/proxy-env.test.js`:补 `getProxyDispatcher` 单测(含全局 dispatcher / `http_proxy` 副作用隔离)。
- `test/proxy.test.js`:`forceIdentityAcceptEncoding` 单测取代原 zstd 测试组。
- `history.md`:新增 `Unreleased` 条目。

## 测试

`npm run test` 全量通过:**2513 tests / 2511 pass / 0 fail**(2 skip 为既有用例)。未 bump 版本(按约定版本号仅在 publish 时改)。

## 后续(不在本 PR 范围)

- `server/lib/plugin-manager.js` 的插件下载 `fetch` 同样未传 dispatcher,外网插件在代理后会绕过——同类隐患,可另开。
