### PR TITLE
feat: add CCV_BASE_PATH env var for reverse proxy sub-path deployment

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -363,7 +363,8 @@ async function runCliMode(extraClaudeArgs = [], cwd, noOpen = false) {
 
   // 4. 自动打开浏览器
   const protocol = serverMod.getProtocol();
-  const url = `${protocol}://127.0.0.1:${port}`;
+  const basePath = process.env.CCV_BASE_PATH || '';
+const url = `${protocol}://127.0.0.1:${port}${basePath}`;
   if (!noOpen) {
     try {
       // URL 含 & 在 cmd.exe 下会被当命令分隔符切断 query；用 spawn 数组传参避免 shell interpolation。
@@ -384,7 +385,7 @@ async function runCliMode(extraClaudeArgs = [], cwd, noOpen = false) {
   const _lanIps = serverMod.getAllLocalIps();
   const _token = serverMod.getAccessToken();
   for (const _ip of _lanIps) {
-    console.log(`  ➜ Network: ${protocol}://${_ip}:${port}?token=${_token}`);
+    console.log(`  ➜ Network: ${protocol}://${_ip}:${port}${basePath}?token=${_token}`);
   }
   // 密码登录已启用时,把当前密码打印出来 —— 否则 `ccv --usePassword`(随机密码)在 CLI 模式下
   // 用户无从得知密码(server.js 的密码打印只在非 CLI 模式生效)。空密码=无防护,给出警告。
@@ -484,7 +485,8 @@ async function runSdkMode(extraClaudeArgs = [], cwd, noOpen = false) {
 
   // 自动打开浏览器
   const protocol = serverMod.getProtocol();
-  const url = `${protocol}://127.0.0.1:${port}`;
+  const basePath = process.env.CCV_BASE_PATH || '';
+const url = `${protocol}://127.0.0.1:${port}${basePath}`;
   if (!noOpen) {
     try {
       // URL 含 & 在 cmd.exe 下会被当命令分隔符切断 query；用 spawn 数组传参避免 shell interpolation。
@@ -505,7 +507,7 @@ async function runSdkMode(extraClaudeArgs = [], cwd, noOpen = false) {
   const _lanIps = serverMod.getAllLocalIps();
   const _token = serverMod.getAccessToken();
   for (const _ip of _lanIps) {
-    console.log(`  ➜ Network: ${protocol}://${_ip}:${port}?token=${_token}`);
+    console.log(`  ➜ Network: ${protocol}://${_ip}:${port}${basePath}?token=${_token}`);
   }
   // 密码登录已启用时,把当前密码打印出来 —— 否则 `ccv --usePassword`(随机密码)在 CLI 模式下
   // 用户无从得知密码(server.js 的密码打印只在非 CLI 模式生效)。空密码=无防护,给出警告。
@@ -561,8 +563,9 @@ async function runCliModeWorkspaceSelector(extraClaudeArgs = [], noOpen = false)
   serverMod.setWorkspaceClaudePath(claudePath, isNpmVersion);
 
   // 自动打开浏览器
+  const basePath = process.env.CCV_BASE_PATH || '';
   const wsProtocol = serverMod.getProtocol();
-  const url = `${wsProtocol}://127.0.0.1:${port}`;
+  const url = `${wsProtocol}://127.0.0.1:${port}${basePath}`;
   if (!noOpen) {
     try {
       // URL 含 & 在 cmd.exe 下会被当命令分隔符切断 query；用 spawn 数组传参避免 shell interpolation。
@@ -583,7 +586,7 @@ async function runCliModeWorkspaceSelector(extraClaudeArgs = [], noOpen = false)
   const _lanIps = serverMod.getAllLocalIps();
   const _token = serverMod.getAccessToken();
   for (const _ip of _lanIps) {
-    console.log(`  ➜ Network: ${wsProtocol}://${_ip}:${port}?token=${_token}`);
+    console.log(`  ➜ Network: ${wsProtocol}://${_ip}:${port}${basePath}?token=${_token}`);
   }
 
   // 注册退出处理

--- a/server/server.js
+++ b/server/server.js
@@ -700,7 +700,9 @@ async function handleRequest(req, res) {
         const basePath = process.env.CCV_BASE_PATH || '';
         if (basePath && basePath !== '/') {
           const safeBase = basePath.replace(/\/?$/, '/');
-          html = html.replace(/<head[^>]*>/i, m => m + `<base href="${safeBase}"><script>window.__CCV_BASE_PATH__="${safeBase}"</script>`);
+                  const escapedBase = safeBase.replace(/&/g, chr(38)+chr(97)+chr(109)+chr(112)+chr(59)).replace(/"/g, chr(38)+chr(113)+chr(117)+chr(111)+chr(116)+chr(59)).replace(/</g, chr(38)+chr(108)+chr(116)+chr(59)).replace(/>/g, chr(38)+chr(103)+chr(116)+chr(59));
+        const jsSafeBase = safeBase.replace(/\/g, chr(92)+chr(92)).replace(/"/g, chr(92)+chr(120)+chr(50)+chr(50)).replace(/<\//g, chr(60)+chr(92)+chr(47));
+        html = html.replace(/<head[^>]*>/i, m => m + `<base href="${escapedBase}"><script>window.__CCV_BASE_PATH__="${jsSafeBase}"</script>`);
         }
         res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8', 'Cache-Control': 'no-cache' });
         res.end(html);
@@ -1017,6 +1019,7 @@ async function setupTerminalWebSocket(httpServer) {
     httpServer.on('upgrade', (req, socket, head) => {
       const wsUrl = new URL(req.url, `${serverProtocol}://${req.headers.host}`);
       const pathname = wsUrl.pathname;
+const bpRaw = process.env.CCV_BASE_PATH || '';      if (bpRaw && bpRaw !== '/' && pathname.startsWith(bpRaw)) {        pathname = pathname.slice(bpRaw.length) || '/';      }
       // 与 HTTP 一致的鉴权（此前 WS upgrade 完全不校验 token，远程终端实为无门禁——本次堵洞）。
       // 在此显式计算 isLocal（与 handleRequest 同款三态判断），WS 视作非 HTML 请求。
       const wsRemoteIp = req.socket.remoteAddress;

--- a/server/server.js
+++ b/server/server.js
@@ -700,8 +700,8 @@ async function handleRequest(req, res) {
         const basePath = process.env.CCV_BASE_PATH || '';
         if (basePath && basePath !== '/') {
           const safeBase = basePath.replace(/\/?$/, '/');
-                  const escapedBase = safeBase.replace(/&/g, chr(38)+chr(97)+chr(109)+chr(112)+chr(59)).replace(/"/g, chr(38)+chr(113)+chr(117)+chr(111)+chr(116)+chr(59)).replace(/</g, chr(38)+chr(108)+chr(116)+chr(59)).replace(/>/g, chr(38)+chr(103)+chr(116)+chr(59));
-        const jsSafeBase = safeBase.replace(/\/g, chr(92)+chr(92)).replace(/"/g, chr(92)+chr(120)+chr(50)+chr(50)).replace(/<\//g, chr(60)+chr(92)+chr(47));
+                  const escapedBase = safeBase.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+        const jsSafeBase = safeBase.replace(/"/g, '"').replace(/<\//g, '<\/');
         html = html.replace(/<head[^>]*>/i, m => m + `<base href="${escapedBase}"><script>window.__CCV_BASE_PATH__="${jsSafeBase}"</script>`);
         }
         res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8', 'Cache-Control': 'no-cache' });
@@ -1018,7 +1018,7 @@ async function setupTerminalWebSocket(httpServer) {
 
     httpServer.on('upgrade', (req, socket, head) => {
       const wsUrl = new URL(req.url, `${serverProtocol}://${req.headers.host}`);
-      const pathname = wsUrl.pathname;
+      let pathname = wsUrl.pathname;
 const bpRaw = process.env.CCV_BASE_PATH || '';      if (bpRaw && bpRaw !== '/' && pathname.startsWith(bpRaw)) {        pathname = pathname.slice(bpRaw.length) || '/';      }
       // 与 HTTP 一致的鉴权（此前 WS upgrade 完全不校验 token，远程终端实为无门禁——本次堵洞）。
       // 在此显式计算 isLocal（与 handleRequest 同款三态判断），WS 视作非 HTML 请求。

--- a/server/server.js
+++ b/server/server.js
@@ -537,7 +537,15 @@ const dispatch = createDispatcher(_routes);
 
 async function handleRequest(req, res) {
   const parsedUrl = new URL(req.url, `${serverProtocol}://${req.headers.host}`);
-  const url = parsedUrl.pathname;
+  let url = parsedUrl.pathname;
+
+  // CCV_BASE_PATH reverse proxy: strip prefix at TOP so API/WS/static/SPA
+  // all work with original unprefixed paths. basePath normalized.
+  const bpRaw = process.env.CCV_BASE_PATH || '';
+  const bp = bpRaw && bpRaw !== '/' ? bpRaw.replace(/\/?$/, '/') : '';
+  if (bp && url.startsWith(bp)) {
+    url = url.slice(bp.length) || '/';
+  }
   const method = req.method;
 
   // WebSocket 路径不处理，交给 upgrade 事件
@@ -692,7 +700,7 @@ async function handleRequest(req, res) {
         const basePath = process.env.CCV_BASE_PATH || '';
         if (basePath && basePath !== '/') {
           const safeBase = basePath.replace(/\/?$/, '/');
-          html = html.replace(/<head[^>]*>/i, m => m + `<base href="${safeBase}">`);
+          html = html.replace(/<head[^>]*>/i, m => m + `<base href="${safeBase}"><script>window.__CCV_BASE_PATH__="${safeBase}"</scr" + "ipt>`);
         }
         res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8', 'Cache-Control': 'no-cache' });
         res.end(html);

--- a/server/server.js
+++ b/server/server.js
@@ -642,7 +642,15 @@ async function handleRequest(req, res) {
 
   // 静态文件服务
   if (method === 'GET') {
-    let filePath = url === '/' ? '/index.html' : url;
+    const rawBase = process.env.CCV_BASE_PATH || '';
+    // Normalize to ensure trailing slash; prevents /proxy/ws from
+    // incorrectly matching /proxy/ws-other due to startsWith ambiguity.
+    const basePath = rawBase && rawBase !== '/' ? rawBase.replace(/\/?$/, '/') : '';
+    let filePath = url;
+    if (basePath && url.startsWith(basePath)) {
+      filePath = url.slice(basePath.length) || '/';
+    }
+    if (filePath === '/') filePath = '/index.html';
     // 去掉 query string
     filePath = filePath.split('?')[0];
 
@@ -679,6 +687,13 @@ async function handleRequest(req, res) {
           console.warn('[serveIndexHtml] dist/index.html 没有 <html data-theme="..."> 属性，SSR theme 注入将不生效。检查 index.html 模板。');
         }
         html = html.replace(/<html([^>]*?)data-theme="[^"]*"/, `<html$1data-theme="${themeColor}"`);
+        // 运行时注入 <base> 标签：当 CCV_BASE_PATH 设置为非空非根路径时，
+        // 使浏览器将所有相对 URL 解析到代理子路径下。配合 Vite base='' 输出相对路径。
+        const basePath = process.env.CCV_BASE_PATH || '';
+        if (basePath && basePath !== '/') {
+          const safeBase = basePath.replace(/\/?$/, '/');
+          html = html.replace(/<head[^>]*>/i, m => m + `<base href="${safeBase}">`);
+        }
         res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8', 'Cache-Control': 'no-cache' });
         res.end(html);
         return true;

--- a/server/server.js
+++ b/server/server.js
@@ -700,7 +700,7 @@ async function handleRequest(req, res) {
         const basePath = process.env.CCV_BASE_PATH || '';
         if (basePath && basePath !== '/') {
           const safeBase = basePath.replace(/\/?$/, '/');
-          html = html.replace(/<head[^>]*>/i, m => m + `<base href="${safeBase}"><script>window.__CCV_BASE_PATH__="${safeBase}"</scr" + "ipt>`);
+          html = html.replace(/<head[^>]*>/i, m => m + `<base href="${safeBase}"><script>window.__CCV_BASE_PATH__="${safeBase}"</script>`);
         }
         res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8', 'Cache-Control': 'no-cache' });
         res.end(html);

--- a/src/AppBase.jsx
+++ b/src/AppBase.jsx
@@ -12,7 +12,7 @@ import { formatTokenCount, filterRelevantRequests, isRelevantRequest, appendCach
 import { snapToPreset, stepPreset } from './utils/displayScaleHelper';
 import { getProjectAlias, subscribeToAlias } from './utils/projectAlias';
 import { isMainAgent, isPostClearCheckpoint } from './utils/contentFilter';
-import { apiUrl } from './utils/apiUrl';
+import { apiUrl, getBasePath } from './utils/apiUrl';
 import { playEvent as playVoiceEvent, unlockAudio, setTurnEndCooldownMs } from './utils/voicePackPlayer';
 import { getDefaultBindingsForLocale as vpDefaultBindingsForLocale } from '../server/lib/voice-pack-events';
 import { mergeVoicePackInto } from '../server/lib/approval-modal-prefs';
@@ -2054,7 +2054,7 @@ class AppBase extends React.Component {
 
   handleOpenLogFile = async (file) => {
     // 优先使用当前 URL 的 token（远程访问时已有）；本地访问时从 /api/local-url 获取带 token 的基础 URL
-    let base = `${window.location.protocol}//${window.location.host}`;
+    let base = `${window.location.protocol}//${window.location.host}${getBasePath()}`;
     let token = new URLSearchParams(window.location.search).get('token');
     if (!token) {
       try {

--- a/src/components/terminal/ScratchTerminal.jsx
+++ b/src/components/terminal/ScratchTerminal.jsx
@@ -127,7 +127,7 @@ class ScratchTerminal extends React.Component {
     if (!id) return; // 没 id 不能连
     const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
     // 带上 LAN token(已有 ?id= → appendToken 用 & 续接);密码登录用户走 cookie。见 TerminalWsContext。
-    const wsUrl = appendToken(`${protocol}//${window.location.host}${getBasePath()}/ws/terminal-scratch?id=${encodeURIComponent(id)}`);
+    const wsUrl = appendToken(`${protocol}//${window.location.host}${getBasePath().replace(/\/$/, chr(39)+chr(39))}/ws/terminal-scratch?id=${encodeURIComponent(id)}`);
     this.ws = new WebSocket(wsUrl);
 
     this.ws.onmessage = (event) => {

--- a/src/components/terminal/ScratchTerminal.jsx
+++ b/src/components/terminal/ScratchTerminal.jsx
@@ -127,7 +127,7 @@ class ScratchTerminal extends React.Component {
     if (!id) return; // 没 id 不能连
     const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
     // 带上 LAN token(已有 ?id= → appendToken 用 & 续接);密码登录用户走 cookie。见 TerminalWsContext。
-    const wsUrl = appendToken(`${protocol}//${window.location.host}${getBasePath().replace(/\/$/, chr(39)+chr(39))}/ws/terminal-scratch?id=${encodeURIComponent(id)}`);
+    const wsUrl = appendToken(`${protocol}//${window.location.host}${getBasePath().replace(/\/$/, '')}/ws/terminal-scratch?id=${encodeURIComponent(id)}`);
     this.ws = new WebSocket(wsUrl);
 
     this.ws.onmessage = (event) => {

--- a/src/components/terminal/ScratchTerminal.jsx
+++ b/src/components/terminal/ScratchTerminal.jsx
@@ -12,7 +12,7 @@ import '@xterm/xterm/css/xterm.css';
 import { darkTerminalTheme, lightTerminalTheme } from './terminalThemes';
 import styles from './TerminalPanel.module.css';
 import { TerminalWriteQueue } from '../../utils/terminalWriteQueue';
-import { appendToken } from '../../utils/apiUrl';
+import { appendToken, getBasePath } from '../../utils/apiUrl';
 
 class ScratchTerminal extends React.Component {
   constructor(props) {
@@ -127,7 +127,7 @@ class ScratchTerminal extends React.Component {
     if (!id) return; // 没 id 不能连
     const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
     // 带上 LAN token(已有 ?id= → appendToken 用 & 续接);密码登录用户走 cookie。见 TerminalWsContext。
-    const wsUrl = appendToken(`${protocol}//${window.location.host}/ws/terminal-scratch?id=${encodeURIComponent(id)}`);
+    const wsUrl = appendToken(`${protocol}//${window.location.host}${getBasePath()}/ws/terminal-scratch?id=${encodeURIComponent(id)}`);
     this.ws = new WebSocket(wsUrl);
 
     this.ws.onmessage = (event) => {

--- a/src/components/terminal/TerminalWsContext.jsx
+++ b/src/components/terminal/TerminalWsContext.jsx
@@ -67,7 +67,7 @@ export class TerminalWsProvider extends React.Component {
       const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
       // 带上 LAN token —— 服务端 WS upgrade 与 HTTP 同款鉴权,远程 ?token= 终端必须携带凭证。
       // 密码登录用户由浏览器自动随握手发送 ccv_auth cookie,此处无 token 时原样返回。
-      url = appendToken(`${protocol}//${window.location.host}${getBasePath().replace(/\/$/, chr(39)+chr(39))}/ws/terminal`);
+      url = appendToken(`${protocol}//${window.location.host}${getBasePath().replace(/\/$/, '')}/ws/terminal`);
     } catch (e) {
       return; // SSR / 测试环境兜底
     }

--- a/src/components/terminal/TerminalWsContext.jsx
+++ b/src/components/terminal/TerminalWsContext.jsx
@@ -1,5 +1,5 @@
 import React, { createContext } from 'react';
-import { appendToken } from '../../utils/apiUrl';
+import { appendToken, getBasePath } from '../../utils/apiUrl';
 
 /**
  * Single shared `/ws/terminal` connection.
@@ -67,7 +67,7 @@ export class TerminalWsProvider extends React.Component {
       const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
       // 带上 LAN token —— 服务端 WS upgrade 与 HTTP 同款鉴权,远程 ?token= 终端必须携带凭证。
       // 密码登录用户由浏览器自动随握手发送 ccv_auth cookie,此处无 token 时原样返回。
-      url = appendToken(`${protocol}//${window.location.host}/ws/terminal`);
+      url = appendToken(`${protocol}//${window.location.host}${getBasePath()}/ws/terminal`);
     } catch (e) {
       return; // SSR / 测试环境兜底
     }

--- a/src/components/terminal/TerminalWsContext.jsx
+++ b/src/components/terminal/TerminalWsContext.jsx
@@ -67,7 +67,7 @@ export class TerminalWsProvider extends React.Component {
       const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
       // 带上 LAN token —— 服务端 WS upgrade 与 HTTP 同款鉴权,远程 ?token= 终端必须携带凭证。
       // 密码登录用户由浏览器自动随握手发送 ccv_auth cookie,此处无 token 时原样返回。
-      url = appendToken(`${protocol}//${window.location.host}${getBasePath()}/ws/terminal`);
+      url = appendToken(`${protocol}//${window.location.host}${getBasePath().replace(/\/$/, chr(39)+chr(39))}/ws/terminal`);
     } catch (e) {
       return; // SSR / 测试环境兜底
     }

--- a/src/utils/apiUrl.js
+++ b/src/utils/apiUrl.js
@@ -19,5 +19,7 @@ export function appendToken(url) {
 }
 
 export function apiUrl(path) {
-  return getBasePath() + appendToken(path);
+  const base = getBasePath();
+  const fullPath = base ? base.replace(/\/$/, '') + path : path;
+  return appendToken(fullPath);
 }

--- a/src/utils/apiUrl.js
+++ b/src/utils/apiUrl.js
@@ -1,6 +1,15 @@
 // 从 URL 中提取 LAN 访问 token，附加到所有 API 请求 / WebSocket 握手
 const _urlToken = new URLSearchParams(window.location.search).get('token');
 
+// 反向代理子路径部署: 从 <base> 标签或 SSR 注入的全局变量读取 base path，
+// 使 API/WebSocket 等动态请求也能正确路由到代理后端。
+export function getBasePath() {
+  if (window.__CCV_BASE_PATH__) return window.__CCV_BASE_PATH__;
+  const base = document.querySelector('base');
+  if (base && base.href) return base.getAttribute('href');
+  return '';
+}
+
 // 把 token 追加到任意 URL（HTTP path 或 ws:// 完整 URL 皆可）。无 token 时原样返回。
 // WS 握手必须也带 token —— 否则启用鉴权后远程「?token=」终端会被 socket.destroy()。
 export function appendToken(url) {
@@ -10,5 +19,5 @@ export function appendToken(url) {
 }
 
 export function apiUrl(path) {
-  return appendToken(path);
+  return getBasePath() + appendToken(path);
 }

--- a/vite.config.js
+++ b/vite.config.js
@@ -15,6 +15,16 @@ const pkg = JSON.parse(readFileSync(new URL('./package.json', import.meta.url), 
 export default defineConfig(() => {
   const port = getBackendPort();
   return {
+    // CCV_BASE_PATH: 部署基础路径。
+    //   未设置 → '/' (默认，向后兼容)
+    //   '/prefix/' → 构建时硬编码前缀
+    //   '' (空字符串) → 相对路径，配合运行时 <base> 标签实现动态代理
+    base: (() => {
+      const v = process.env.CCV_BASE_PATH;
+      if (v === undefined) return '/';
+      if (v === '') return '';                 // relative paths, no trailing slash fixup
+      return v.replace(/\/?$/, '/');           // ensure trailing slash
+    })(),
     plugins: [react()],
     define: {
       __APP_VERSION__: JSON.stringify(pkg.version),


### PR DESCRIPTION
## 概述

当 cc-viewer 运行在反向代理的子路径下时（如 `/proxy/myproject/abc123/`），此 PR 添加 `CCV_BASE_PATH` 环境变量支持。

## 三种模式

| CCV_BASE_PATH | Vite base | 行为 | 适用场景 |
|:---|:---|:---|:---|
| 未设置 | `/` | 默认，向后兼容 | 直接使用 |
| `/prefix/` | `/prefix/` | 构建时硬编码前缀 | 固定子路径部署 |
| `""` (空字符串) | `""` | **相对路径** + 运行时 `<base>` 注入 | 动态代理 |

## 修改文件

**vite.config.js**: 读取 `CCV_BASE_PATH` 作为 Vite `base` 配置，空字符串=相对路径

**server/server.js**:
1. `handleRequest()` **顶部**统一剥离 basePath 前缀 — API 路由、WebSocket 升级、静态文件、SPA 均受益
2. `serveIndexHtml()` 运行时注入 `<base>` 标签 + `window.__CCV_BASE_PATH__` 全局变量

**src/utils/apiUrl.js**: 新增 `getBasePath()` helper，`apiUrl()` 自动拼接 basePath

**src/components/terminal/TerminalWsContext.jsx + ScratchTerminal.jsx**: WebSocket URL 拼接 basePath

**cli.js**: 启动 URL 包含 basePath

## 向后兼容

- 未设置 `CCV_BASE_PATH` 时行为与之前完全一致
- Vite `base` 保持 `/`，server 不处理前缀，前端 `getBasePath()` 返回 `""`

## 使用示例

```bash
# 模式 3: 构建一次，运行时动态设置
CCV_BASE_PATH= npm run build
CCV_BASE_PATH=/proxy/myproject/abc123/ ccv -c --d
```