### PR TITLE
fix(perf): cap desktop render window + extend SSE backpressure tolerance (Windows long-task freeze)

### DIFF
--- a/history.md
+++ b/history.md
@@ -24,6 +24,8 @@
 - fix(electron/win): 主进程防阻塞加固，针对 Windows 整窗永久冻结（渲染存活、hover 有高亮但全程无响应）——diag 日志 `appendFileSync` 改异步队列（256 条上限防错误风暴）；打包版主进程 console 输出静默、worker stdio 改 ignore（消除终端启动 + QuickEdit 点选导致的内核级写阻塞面）；审批级联（badge/flashFrame/广播）100ms 去抖合并
 - fix(electron/win): 全部 child_process 调用点统一补 `windowsHide: true`，修复 Windows 桌面版启动多弹一个 Node.js 控制台窗口；新增静态扫描测试防回归
 - feat(ui): 版本信息弹窗按安装渠道（electron / brew / npm）精准匹配升级命令——npm 命令补 `--registry` 指定官方源避免镜像滞后，brew 渠道提示 `brew upgrade cc-viewer`（补 18 语言）
+- fix(perf): 修复 Web 桌面端长任务中后段「整个页面卡死/偶发崩溃」（Windows 高发、Mac 不复现）——桌面端原先不做虚拟化(`useVirtuoso` 仅移动端)且不裁剪渲染窗口，长会话把整段对话全量渲染成 DOM，单次更新 reconcile/layout 成本随条目数线性增长，主线程被打满（Windows 大 DOM layout 更重、渲染器内存上限更低，先于 Mac 撞上上限）。现桌面端复用移动端的渲染窗口裁剪：默认只渲染最近 400 条 item，更早的经「加载更早」按需展开（搜索/跳转到被裁剪区域时自动展开纳入）
+- fix(perf): SSE 单客户端 backpressure 容忍上限 5s→30s——大会话首屏/重连重放时短暂忙碌的渲染器不再被误判 dead 而剔除，避免「断开→EventSource 自动重连→再次重放」风暴把瞬时卡顿放大成持续卡死
 - feat(ui): 顶栏「网络报文 / 对话模式」切换按钮文案精简为「网络 / 对话」；对话中居中的 SVG loading 动画设为不可选中（user-select:none + pointer-events:none）
 - feat(ui): 偏好设置「对话展示」多项设置追加 (?) 悬浮说明（权限自动审批 / 弹出全局审批 Modal / 审批提示音 / 展开思考过程 / 完整展示所有内容，补 18 语言）
 - feat(ui): 代理热切换的「Max 用户请勿使用」告警改为仅当 Default(内置)端点为 api.anthropic.com 时显示

--- a/server/lib/log-watcher.js
+++ b/server/lib/log-watcher.js
@@ -55,7 +55,10 @@ export function readLogFile(logFile) {
   }
 }
 
-const SSE_BACKPRESSURE_TIMEOUT_MS = 5000;
+// SSE 单客户端 backpressure 容忍上限：连续未排空 > 此时长则视为 dead 客户端剔除。
+// 与 server.js 同名常量值保持一致（避免循环依赖，此处单独 mirror）。
+// 30s：避免大会话/重连重放时把短暂忙碌的渲染器误判为 dead 并触发重连风暴，详见 server.js 注释。
+const SSE_BACKPRESSURE_TIMEOUT_MS = 30000;
 
 function _removeClient(clients, client) {
   const idx = clients.indexOf(client);

--- a/server/server.js
+++ b/server/server.js
@@ -293,7 +293,10 @@ const MAX_POST_BODY = 10 * 1024 * 1024;
 // 用户显式 ?limit=0 可恢复全量加载（power-user 逃生口）。
 const DEFAULT_EVENTS_LIMIT = 1000;
 // SSE 单客户端 backpressure 容忍上限：连续未排空 > 此时长则视为 dead 客户端剔除。
-const SSE_BACKPRESSURE_TIMEOUT_MS = 5000;
+// 调高至 30s：大会话首屏/重连重放时，渲染器（尤其 Windows 浏览器，大 DOM layout 更重）
+// 可能短暂忙到来不及排空 socket。过早剔除会触发「断开→EventSource 自动重连→再次重放」
+// 风暴，把瞬时卡顿放大成持续卡死。30s 仍能剔除真正死掉的连接。
+const SSE_BACKPRESSURE_TIMEOUT_MS = 30000;
 
 
 

--- a/src/components/chat/ChatView.jsx
+++ b/src/components/chat/ChatView.jsx
@@ -72,6 +72,12 @@ const AUTO_ALLOW_PTY_DEDUPE_MS = 2000;
 const MOBILE_ITEM_LIMIT = 240;
 const IOS_ITEM_LIMIT = 150;
 const MOBILE_LOAD_MORE_STEP = 100;
+// 桌面端初始渲染上限。桌面不走虚拟化（useVirtuoso 仅 isMobile），长任务会把整段对话全量渲染成
+// DOM，中后段 reconcile/layout 成本随条目数线性增长 → 主线程卡死（Windows 比 Mac 先撞上上限）。
+// 与移动端一致：只渲染最近 N 条 item，更早的用「加载更早」按需展开。桌面给更大窗口。
+const DESKTOP_ITEM_LIMIT = 400;
+// 当前平台基础渲染上限。isMobile/isIOS 在模块加载时即固定（见 env.js），故可一次性求值。
+const ITEM_LIMIT = isMobile ? (isIOS ? IOS_ITEM_LIMIT : MOBILE_ITEM_LIMIT) : DESKTOP_ITEM_LIMIT;
 const useVirtuoso = isMobile && !isIOS && !isPad;
 
 // 稳定空对象引用，避免每次 render 创建新 {} 导致子组件重渲染
@@ -730,7 +736,8 @@ class ChatView extends React.Component {
         }
         this._prevSessions = this.props.mainAgentSessions;
       }
-      if (isMobile) this._mobileExtraItems = 0;
+      // 会话/工作区切换：复位「加载更早」展开量，新会话从最近窗口开始（移动端+桌面端一致）
+      this._mobileExtraItems = 0;
       this.startRender();
       if (this.state.pendingInput) {
         this.setState({ pendingInput: null });
@@ -774,26 +781,20 @@ class ChatView extends React.Component {
     }
     // scrollToTimestamp 变化时（如从 raw 模式切回 chat），重建 items 并滚动定位
     if (!prevProps.scrollToTimestamp && this.props.scrollToTimestamp) {
-      // If target is in hidden area, expand to include it
-      if (isMobile && this.props.scrollToTimestamp) {
-        const rawItems = this.buildAllItems();
-        const targetIdx = this._scrollTargetIdx;
-        if (targetIdx != null) {
-          const mobileLimit = isIOS ? IOS_ITEM_LIMIT : MOBILE_ITEM_LIMIT;
-          const limit = mobileLimit + this._mobileExtraItems;
-          const offset = rawItems.length > limit ? rawItems.length - limit : 0;
-          if (targetIdx < offset) {
-            this._mobileExtraItems = rawItems.length - targetIdx - mobileLimit;
-            if (this._mobileExtraItems < 0) this._mobileExtraItems = 0;
-          }
+      // 跳转目标若落在被裁剪（未渲染）的更早区域，先展开 _mobileExtraItems 把它纳入可见窗口，
+      // 否则跳转/搜索定位会失败。移动端与桌面端统一处理（桌面端启用渲染窗口裁剪后同样需要）。
+      const rawItems = this.buildAllItems();
+      const targetIdx = this._scrollTargetIdx;
+      if (targetIdx != null) {
+        const limit = ITEM_LIMIT + this._mobileExtraItems;
+        const offset = rawItems.length > limit ? rawItems.length - limit : 0;
+        if (targetIdx < offset) {
+          this._mobileExtraItems = rawItems.length - targetIdx - ITEM_LIMIT;
+          if (this._mobileExtraItems < 0) this._mobileExtraItems = 0;
         }
-        const allItems = this._applyMobileSlice(rawItems);
-        this.setState({ allItems, lastResponseItems: this._lastResponseItems, visibleCount: allItems.length }, () => this.scrollToBottom());
-      } else {
-        const rawItems = this.buildAllItems();
-        const allItems = this._applyMobileSlice(rawItems);
-        this.setState({ allItems, lastResponseItems: this._lastResponseItems, visibleCount: allItems.length }, () => this.scrollToBottom());
       }
+      const allItems = this._applyMobileSlice(rawItems);
+      this.setState({ allItems, lastResponseItems: this._lastResponseItems, visibleCount: allItems.length }, () => this.scrollToBottom());
     }
     // mobileChatVisible: scroll to bottom when becoming visible
     if (isMobile && this.props.mobileChatVisible && !prevProps.mobileChatVisible) {
@@ -1926,14 +1927,11 @@ class ChatView extends React.Component {
     return allItems;
   }
 
+  // 渲染窗口裁剪：只保留最近 ITEM_LIMIT(+已展开) 条 item。移动端与桌面端统一处理
+  // （桌面端启用裁剪以避免长任务全量渲染卡死，见 DESKTOP_ITEM_LIMIT 注释）。
   _applyMobileSlice(allItems) {
-    if (!isMobile) {
-      this._mobileSliceOffset = 0;
-      this._totalItemCount = allItems.length;
-      return allItems;
-    }
     this._totalItemCount = allItems.length;
-    const limit = (isIOS ? IOS_ITEM_LIMIT : MOBILE_ITEM_LIMIT) + this._mobileExtraItems;
+    const limit = ITEM_LIMIT + this._mobileExtraItems;
     if (allItems.length <= limit) {
       this._mobileSliceOffset = 0;
       return allItems;
@@ -3446,7 +3444,7 @@ class ChatView extends React.Component {
       </button>
     ) : null;
 
-    const loadMoreBtn = isMobile && this._mobileSliceOffset > 0 ? (
+    const loadMoreBtn = this._mobileSliceOffset > 0 ? (
       <div className={styles.loadMoreWrap}>
         <button className={styles.loadMoreBtn} onClick={this.handleLoadMore}>
           {t('ui.loadMoreHistory', { count: this._mobileSliceOffset })}

--- a/test/events-backpressure.test.js
+++ b/test/events-backpressure.test.js
@@ -76,17 +76,17 @@ describe('SSE backpressure: _safeSseWrite via sendToClients', () => {
     assert.equal(c.writes.length, 0);
   });
 
-  it('keeps backpressured client on first write-false (sets timestamp), then removes after >5s', () => {
+  it('keeps backpressured client on first write-false (sets timestamp), then removes after tolerance window', () => {
     const c = new FakeClient('full');
     const clients = [c];
     // 第一次 write 返 false：标记时间戳但不剔除
     sendToClients(clients, { ts: 1 });
     assert.equal(clients.length, 1, 'still in array on first backpressure');
     assert.ok(c._sseBackpressureSince, 'backpressure timestamp set');
-    // 模拟时钟前进 6s（超过 5s 上限）
-    c._sseBackpressureSince = Date.now() - 6000;
+    // 模拟未排空持续远超容忍窗口（不绑定具体常量值，直接把起点推到很久以前）
+    c._sseBackpressureSince = Date.now() - 10 * 60 * 1000;
     sendToClients(clients, { ts: 2 });
-    assert.equal(clients.length, 0, 'removed after >5s sustained backpressure');
+    assert.equal(clients.length, 0, 'removed after sustained backpressure beyond tolerance window');
     assert.ok(c.ended, 'client.end() called');
   });
 

--- a/test/log-watcher.test.js
+++ b/test/log-watcher.test.js
@@ -122,6 +122,29 @@ describe('sendToClients', () => {
     // Should not throw
     sendToClients([], { timestamp: 1, url: '/test' });
   });
+
+  it('keeps a backpressured client until the tolerance window elapses, then drops it', () => {
+    // write 返回 false 模拟写缓冲满（backpressure）。首次推送只记录时间戳并挂 drain 监听，
+    // 不应立即剔除——否则瞬时忙碌的渲染器会被误判 dead，触发重连风暴（Windows 卡死放大器）。
+    let ended = false;
+    const client = {
+      write: () => false,
+      once: () => {},
+      end: () => { ended = true; },
+    };
+    const clients = [client];
+
+    sendToClients(clients, { timestamp: 1, url: '/test' });
+    assert.equal(clients.length, 1, 'first backpressured push must not drop the client');
+    assert.equal(ended, false);
+    assert.ok(client._sseBackpressureSince > 0, 'backpressure start timestamp recorded');
+
+    // 模拟未排空持续超过容忍窗口（不依赖具体常量值，直接把起点推到很久以前）。
+    client._sseBackpressureSince = Date.now() - 10 * 60 * 1000;
+    sendToClients(clients, { timestamp: 2, url: '/test' });
+    assert.equal(clients.length, 0, 'client is dropped after the tolerance window without draining');
+    assert.equal(ended, true, 'dropped client is end()-ed');
+  });
 });
 
 describe('watchLogFile (fs.watch migration)', () => {


### PR DESCRIPTION
## Problem

In **web** sessions, the desktop UI becomes **fully non-interactive** ("画面卡死") in the **mid-to-late stage of long tasks**, and occasionally crashes outright (very low probability). This reproduces on **Windows** but **never on Mac**.

## Root cause

This is a **frontend resource cliff**, not a server stall (only a blocked browser main thread makes the *whole page* non-interactive; only renderer memory exhaustion produces the rare crash). Mac and Windows run the **identical** code path — the difference is the runtime ceiling, so Windows crosses the cliff at the conversation sizes long tasks produce while the Mac stays under it.

- **Desktop never virtualizes** (`useVirtuoso = isMobile && !isIOS && !isPad`) and never capped the rendered window, so a long conversation renders the **entire** message list as real DOM (`visible.map(...)`). Per-update reconcile/layout cost grows linearly with item count ⇒ cumulative ≈ O(N²) over a task ⇒ main thread saturates. Windows hits the wall first (heavier large-DOM text layout via DirectWrite, lower Chrome renderer memory ceiling, GC pressure).
- **Amplifier:** once the renderer slows, the server's 5s SSE backpressure drop + the client's auto-reconnect re-stream history again → another big batch → more blocking, turning a transient stall into a sustained freeze.

### Ruled out (verified, not the cause)
CRLF/line-ending split (writer always emits literal `\n---\n`; `JSON.stringify` escapes inner newlines) · "`watchFile` polls only on Windows" (it polls on all platforms) · path-comparison rotation loop (`logFile` and `getLogFile()` are the same `LOG_FILE` variable) · unbounded live streaming overlay (single replaced object, rAF + `startTransition`).

## Changes (low-risk mitigations)

- **Cap the desktop render window** (`src/components/chat/ChatView.jsx`): reuse the existing mobile slice machinery on desktop — render only the most recent `DESKTOP_ITEM_LIMIT` (400) items, with the existing **"load older"** affordance (`ui.loadMoreHistory`, already translated) to expand on demand. Jump/search into a trimmed-out message auto-expands the window. This bounds DOM size — and the dominant renderer memory (DOM/fiber for large markdown) — regardless of task length, so neither platform can reach the freeze cliff.
- **Extend SSE backpressure tolerance 5s → 30s** (`server/server.js`, `server/lib/log-watcher.js`): a momentarily-busy renderer during a large initial/reconnect replay is no longer misjudged "dead" and dropped, which otherwise triggers the disconnect → auto-reconnect → replay storm. 30s still evicts genuinely dead connections.

## Tests / build

- Added a unit test for the backpressure keep/drop behavior (`test/log-watcher.test.js`) and made the existing backpressure test robust to the timeout constant (`test/events-backpressure.test.js`).
- `npm run test`: all tests related to these changes pass. The only failures in the suite are pre-existing and environment-specific (temp-repo git commit **signing** returns HTTP 400 in this CI container; one server test is flaky under parallel load) — unrelated to this diff.
- `npm run build`: succeeds.
- `history.md` updated. No new i18n keys (reuses `ui.loadMoreHistory`); no README change needed.

## Deliberately deferred (follow-ups, higher integration risk — want Windows testing first)

- **Desktop IndexedDB cold-session eviction** to bound the underlying in-memory session data (the render cap already bounds the DOM/fiber memory that dominates). Requires wiring the cold→hot restore path to the desktop "load older" action.
- **Incremental SSE reconnect on desktop** (use the `since` path so a reconnect doesn't replay the capped history). With the render cap in place, a replay no longer freezes the DOM, so this is no longer urgent.

https://claude.ai/code/session_01JorFF3ryEuVYniGdMDeigg

---
_Generated by [Claude Code](https://claude.ai/code/session_01JorFF3ryEuVYniGdMDeigg)_