### PR TITLE
feat: add CCV_DISABLE_ASK_HOOK to opt out of web AskUserQuestion interception

### DIFF
--- a/concepts/en/GlobalSettings.md
+++ b/concepts/en/GlobalSettings.md
@@ -66,6 +66,7 @@ All UI settings are persisted to `<log_dir>/preferences.json` via the `/api/pref
 | `CCV_PROJECT_DIR` | `process.cwd()` | Project working directory for file operations and Git commands |
 | `CCV_PROXY_PORT` | unset | Local MITM proxy port |
 | `CCV_BYPASS_PERMISSIONS` | unset | `=1` skip tool permission approval (with `--dangerously-skip-permissions`) |
+| `CCV_DISABLE_ASK_HOOK` | unset | `=1` skip cc-viewer's web AskUserQuestion prompt; let it fall through to the terminal / a downstream PermissionRequest hook |
 | `CCV_DISABLE_DELTA` | unset | `=1` disable incremental log storage, write full messages every time |
 | `CCV_DEBUG` | unset | `=1` enable HTTP proxy debug logging |
 | `CCV_DEBUG_PLUGINS` | unset | `=1` enable plugin loading debug logging |

--- a/concepts/zh/GlobalSettings.md
+++ b/concepts/zh/GlobalSettings.md
@@ -66,6 +66,7 @@
 | `CCV_PROJECT_DIR` | `process.cwd()` | 项目工作目录，用于文件操作和 Git 命令 |
 | `CCV_PROXY_PORT` | 未设置 | 本地 MITM 代理端口 |
 | `CCV_BYPASS_PERMISSIONS` | 未设置 | `=1` 跳过工具权限审批（配合 `--dangerously-skip-permissions`） |
+| `CCV_DISABLE_ASK_HOOK` | 未设置 | `=1` 跳过 cc-viewer 网页端 AskUserQuestion 答题，交回终端 / 下游 PermissionRequest hook 处理 |
 | `CCV_DISABLE_DELTA` | 未设置 | `=1` 禁用增量日志存储，每次写入完整消息 |
 | `CCV_DEBUG` | 未设置 | `=1` 启用 HTTP 代理调试日志 |
 | `CCV_DEBUG_PLUGINS` | 未设置 | `=1` 启用插件加载调试日志 |

--- a/server/lib/ask-bridge.js
+++ b/server/lib/ask-bridge.js
@@ -40,6 +40,17 @@ if (!port) {
   process.exit(0);
 }
 
+// Opt-out: skip cc-viewer's web AskUserQuestion interception and let the prompt fall
+// through to the terminal TUI / any downstream PreToolUse|PermissionRequest hooks
+// (e.g. a desktop notifier that renders the options elsewhere). Runtime env gate,
+// mirroring CCV_BYPASS_PERMISSIONS in perm-bridge.js — the hook stays registered, so
+// this toggles per-launch with no settings.json churn. Emitting continue:true (rather
+// than exit 1) avoids Claude Code logging a "hook error" on every AskUserQuestion call.
+if (process.env.CCV_DISABLE_ASK_HOOK === '1') {
+  process.stdout.write(JSON.stringify({ continue: true, suppressOutput: true }) + '\n');
+  process.exit(0);
+}
+
 let stdinData;
 try {
   stdinData = readFileSync(0, 'utf-8');

--- a/test/ask-bridge.test.js
+++ b/test/ask-bridge.test.js
@@ -368,4 +368,60 @@ describe('ask-bridge.js', () => {
       });
     });
   });
+
+  describe('CCV_DISABLE_ASK_HOOK opt-out', () => {
+    let server;
+    let port;
+    let requestCount;
+
+    beforeEach(async () => {
+      requestCount = 0;
+      server = createServer((req, res) => {
+        requestCount++;
+        req.resume();
+        req.on('end', () => {
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ answers: { 'Q?': 'A' } }));
+        });
+      });
+      await new Promise((resolve) => {
+        server.listen(0, '127.0.0.1', () => { port = server.address().port; resolve(); });
+      });
+    });
+
+    afterEach(async () => {
+      await new Promise((resolve) => server.close(resolve));
+    });
+
+    const STDIN = JSON.stringify({
+      tool_input: { questions: [{ question: 'Q?', header: 'H', options: [{ label: 'A', description: '' }], multiSelect: false }] },
+    });
+
+    it('falls through (continue:true) WITHOUT contacting the server when set to "1"', async () => {
+      const { code, stdout } = await runBridge(STDIN, { CCVIEWER_PORT: String(port), CCV_DISABLE_ASK_HOOK: '1' });
+      assert.equal(code, 0);
+      const output = JSON.parse(stdout.trim());
+      assert.equal(output.continue, true);
+      assert.equal(output.suppressOutput, true);
+      // The whole point: the prompt is handed to the terminal / a downstream PermissionRequest
+      // hook, so cc-viewer's ask endpoint must never be hit.
+      assert.equal(requestCount, 0, 'disabled ask hook must not reach the server');
+    });
+
+    it('keeps intercepting (contacts server, returns answers) when the flag is unset', async () => {
+      const { code, stdout } = await runBridge(STDIN, { CCVIEWER_PORT: String(port), CCV_DISABLE_ASK_HOOK: '' });
+      assert.equal(code, 0);
+      const output = JSON.parse(stdout.trim());
+      assert.equal(output.hookSpecificOutput.permissionDecision, 'allow');
+      assert.ok(requestCount >= 1, 'unset flag preserves the existing interception behavior');
+    });
+
+    it('treats values other than "1" as unset (still intercepts)', async () => {
+      const { code, stdout } = await runBridge(STDIN, { CCVIEWER_PORT: String(port), CCV_DISABLE_ASK_HOOK: 'true' });
+      assert.equal(code, 0);
+      const output = JSON.parse(stdout.trim());
+      assert.equal(output.hookSpecificOutput.permissionDecision, 'allow');
+      assert.ok(requestCount >= 1, 'only the exact value "1" disables — mirrors CCV_BYPASS_PERMISSIONS');
+    });
+  });
 });


### PR DESCRIPTION
## Problem

When `CCVIEWER_PORT` is set, `server/lib/ask-bridge.js` intercepts **every**
`AskUserQuestion` at the `PreToolUse` stage and answers it through the cc-viewer
web UI (returning `permissionDecision: allow` + `updatedInput`).

A `PreToolUse` `allow` short-circuits the rest of the tool lifecycle, so the prompt
never reaches the **terminal TUI** or any **downstream `PermissionRequest` hook**.
That's a problem for anyone who wants to answer `AskUserQuestion` somewhere other
than the cc-viewer web UI — e.g. a desktop notifier that renders the options and
replies via a `PermissionRequest` hook. cc-viewer always wins the race, and there's
currently no supported way to turn it off short of unsetting `CCVIEWER_PORT` (which
also disables perm-bridge / turn-end-bridge).

## Change

Add an opt-out env var **`CCV_DISABLE_ASK_HOOK=1`**. When set, `ask-bridge.js`
emits `{continue:true, suppressOutput:true}` and exits **before** contacting the
server, letting the prompt fall through to the terminal / downstream hooks.

Design mirrors the existing `CCV_BYPASS_PERMISSIONS` gate in `perm-bridge.js`:

- **Runtime env gate** inside the bridge — the hook stays registered by
  `ensure-hooks.js`, so it toggles per-launch with no `settings.json` churn.
- `continue:true` (not `exit 1`) so Claude Code doesn't log a "hook error" on
  every `AskUserQuestion` call.
- Only the exact value `"1"` activates it, consistent with `CCV_BYPASS_PERMISSIONS`.

## Tests

`test/ask-bridge.test.js` — new `CCV_DISABLE_ASK_HOOK opt-out` block:

- `=1` → `continue:true` and the mock ask endpoint gets **0 hits** (proves it
  short-circuits before any network call, not just falls back after one).
- unset → unchanged: contacts the server and returns answers.
- `"true"` (any non-`"1"`) → treated as unset, still intercepts.

```
# tests 19  # pass 19  # fail 0
```
`npm run lint:control-bytes` clean.

## Docs

Documented in `concepts/en/GlobalSettings.md` and `concepts/zh/GlobalSettings.md`
(other locales can be synced via your i18n process).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
